### PR TITLE
feat: rename Skill display labels for finishing and rebounding (#20)

### DIFF
--- a/backend/services/claude_assessment.py
+++ b/backend/services/claude_assessment.py
@@ -51,7 +51,7 @@ _SKILL_DISPLAY_NAMES: dict[str, str] = {
     "cutter":             "Cutter",
     "movement_shooter":   "Movement Shooter",
     "passer":             "Passer",
-    "crafty_finisher":    "Crafty Finisher",
+    "crafty_finisher":    "Below the Rim Finishing",
     "driver":             "Driver",
     "mid_post_player":    "Mid Post Player",
     "low_post_player":    "Low Post Player",
@@ -62,7 +62,7 @@ _SKILL_DISPLAY_NAMES: dict[str, str] = {
     "pnr_finisher":       "PnR Finisher",
     "versatile_defender": "Versatile Defender",
     "perimeter_disruptor": "Perimeter Disruptor",
-    "high_flyer":         "High Flyer",
+    "high_flyer":         "Above the Rim Finishing",
 }
 
 # Definitions scoped to the skills Claude actually evaluates (moderate + low)
@@ -270,7 +270,7 @@ def _build_informed_section(stat_skills_result: dict) -> str:
     hf_driving = hf.get("driving_stats", {})
     hf_stats_str = _format_driving_stats_inline(hf_driving)
     lines += [
-        "### high_flyer (High Flyer)",
+        "### high_flyer (Above the Rim Finishing)",
         "Possesses elite explosive athleticism for above-the-rim plays, highlight dunks, "
         "and transition finishes.",
         f"The stats show: {hf_stats_str}",

--- a/backend/services/skills.py
+++ b/backend/services/skills.py
@@ -76,7 +76,7 @@ SKILL_DEFINITIONS: dict[str, str] = {
     "passer":              "Creates quality shot opportunities for teammates through vision and passing skill.",
     "offensive_rebounder": "Consistently crashes offensive boards and converts second-chance opportunities.",
     "vertical_spacer":     "Threatens vertically as a lob target and above-the-rim finisher, creating driving lanes for teammates.",
-    "rebounder":           "Consistently grabs defensive and offensive boards through positioning and effort.",
+    "rebounder":           "Consistently secures defensive boards through positioning, boxing out, and effort.",
     "rim_protector":       "Deters and blocks shots at the rim, altering opponent finishing attempts.",
     "screen_setter":       "Sets quality screens that free teammates for open shots.",
     "mid_post_player":     "Scores effectively from the mid-post/elbow area using face-up moves and mid-range shooting.",

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,7 +12,7 @@ const SAMPLE_SKILLS = [
   { name: "Passer", tier: "Proficient" as const },
   { name: "Versatile Defender", tier: "Capable" as const },
   { name: "Perimeter Disruptor", tier: "Elite" as const },
-  { name: "Rebounder", tier: "Capable" as const },
+  { name: "Defensive Rebounding", tier: "Capable" as const },
 ];
 
 const TIER_STYLES: Record<string, string> = {

--- a/frontend/lib/cohesion-constants.ts
+++ b/frontend/lib/cohesion-constants.ts
@@ -146,7 +146,7 @@ export const SYNERGY_DESCRIPTIONS: Record<string, string> = {
   "OFF-15": "Vertical spacers are penalized without passers or drivers to activate them.",
   "OFF-16": "Passers or drivers boost vertical spacers as lob and rim-pressure targets.",
   "OFF-31": "Passers boost transition threats in the open court.",
-  "OFF-32": "Transition threats and passers boost high flyers.",
+  "OFF-32": "Transition threats and passers boost Above the Rim Finishers.",
   "OFF-37": "Only one passer is present, making playmaking fragile.",
 };
 

--- a/frontend/lib/skills.ts
+++ b/frontend/lib/skills.ts
@@ -58,7 +58,7 @@ export const SKILL_LABELS: Record<string, string> = {
   spot_up_shooter:          "Spot Up Shooter",
   off_dribble_shooter:      "Off-Dribble Shooter",
   offensive_rebounder:      "Offensive Rebounder",
-  rebounder:                "Rebounder",
+  rebounder:                "Defensive Rebounding",
   rim_protector:            "Rim Protector",
   isolation_scorer:         "Isolation Scorer",
   movement_shooter:         "Movement Shooter",
@@ -66,7 +66,7 @@ export const SKILL_LABELS: Record<string, string> = {
   transition_threat:        "Transition Threat",
   pnr_ball_handler:         "PnR Ball Handler",
   pnr_finisher:             "PnR Finisher",
-  crafty_finisher:          "Crafty Finisher",
+  crafty_finisher:          "Below the Rim Finishing",
   driver:                   "Driver",
   vertical_spacer:          "Vertical Spacer",
   screen_setter:            "Screen Setter",
@@ -75,7 +75,7 @@ export const SKILL_LABELS: Record<string, string> = {
   low_post_player:          "Low-Post Player",
   versatile_defender:       "Versatile Defender",
   perimeter_disruptor:      "Perimeter Disruptor",
-  high_flyer:               "High Flyer",
+  high_flyer:               "Above the Rim Finishing",
 };
 
 /** Human-readable skill definitions. Mirrors backend/services/skills.py. */
@@ -83,7 +83,7 @@ export const SKILL_DESCRIPTIONS: Record<string, string> = {
   spot_up_shooter:          "Hits catch-and-shoot three-pointers and mid-range shots from set positions.",
   off_dribble_shooter:      "Creates and converts shots off the dribble, including pull-ups and step-backs.",
   offensive_rebounder:      "Consistently crashes offensive boards and converts second-chance opportunities.",
-  rebounder:                "Consistently grabs defensive and offensive boards through positioning and effort.",
+  rebounder:                "Consistently secures defensive boards through positioning, boxing out, and effort.",
   rim_protector:            "Deters and blocks shots at the rim, altering opponent finishing attempts.",
   isolation_scorer:         "Beats defenders one-on-one in isolation situations through dribble moves and athleticism.",
   movement_shooter:         "Hits shots while relocating off screens and handoffs, not just standing still.",
@@ -119,7 +119,7 @@ export const SKILL_ABBREV: Record<string, string> = {
   spot_up_shooter:          "Spot Up",
   off_dribble_shooter:      "Off Drib",
   offensive_rebounder:      "Off Reb",
-  rebounder:                "Reb",
+  rebounder:                "Def Reb",
   rim_protector:            "Rim Prot",
   isolation_scorer:         "Iso",
   movement_shooter:         "Move Shoot",
@@ -127,7 +127,7 @@ export const SKILL_ABBREV: Record<string, string> = {
   transition_threat:        "Trans",
   pnr_ball_handler:         "PnR BH",
   pnr_finisher:             "PnR Fin",
-  crafty_finisher:          "Crafty",
+  crafty_finisher:          "Below Rim",
   driver:                   "Driver",
   vertical_spacer:          "V-Space",
   screen_setter:            "Screener",
@@ -136,7 +136,7 @@ export const SKILL_ABBREV: Record<string, string> = {
   low_post_player:          "Lo Post",
   versatile_defender:       "Versa Def",
   perimeter_disruptor:      "Perim Disr",
-  high_flyer:               "Hi Fly",
+  high_flyer:               "Above Rim",
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #20.

Display-only Skill label rename. No Skill Profile API keys, DB columns, or threshold map keys touched — all identifiers (`high_flyer`, `crafty_finisher`, `rebounder`) remain the same so historical Saved Teams and serialized Skill Profiles stay compatible.

Label changes (old → new):

- `high_flyer`: **High Flyer** → **Above the Rim Finishing** (abbrev `Hi Fly` → `Above Rim`)
- `crafty_finisher`: **Crafty Finisher** → **Below the Rim Finishing** (abbrev `Crafty` → `Below Rim`)
- `rebounder`: **Rebounder** → **Defensive Rebounding** (abbrev `Reb` → `Def Reb`)

Skill descriptions and definitions tightened to match: `rebounder` is now scoped to defensive boards in both frontend and backend copy.

## Files touched

- `frontend/lib/skills.ts` — `SKILL_LABELS`, `SKILL_ABBREV`, `SKILL_DESCRIPTIONS`
- `frontend/app/page.tsx` — landing page sample Skill name
- `backend/services/skills.py` — `SKILL_LABELS`, `SKILL_DEFINITIONS`, `_SKILL_DISPLAY_NAMES`
- `backend/services/claude_assessment.py` — Claude prompt Skill name headers

## Deliberately left alone

Generic English "rebounder" usage inside cohesion engine descriptions (cohesion-constants, cohesion notes, subscore equations, weights comments). Those describe any board-grabbing Player blending offensive + defensive boards, not the specific `rebounder` Skill — renaming would mislead. Spelled out in the bg agent report.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `python -m pytest tests/ -q` — 371 passed
- [x] Open Player Profile, confirm the three Skills display the new labels (Above the Rim Finishing, Below the Rim Finishing, Defensive Rebounding)
- [x] Open admin Calibration page, confirm thresholds for these Skills still load (keys unchanged)
- [x] Open a Saved Team's evaluation, confirm Skill names display with the new labels and the engine math is unchanged