### PR TITLE
feat: add community Teams slideshow to landing Hero (#29)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { HeroSlideshow } from "@/components/landing/HeroSlideshow";
 
 /* ── Sample data for the proof section ──
    Hardcoded realistic skill profiles to demonstrate the system visually.
@@ -69,53 +70,82 @@ export default function LandingPage() {
           }}
         />
 
-        <div className="relative max-w-screen-xl mx-auto px-6 py-24 md:py-32 lg:py-40">
-          {/* Left-aligned layout — not a centered stack */}
-          <div className="max-w-2xl">
-            {/* Eyebrow label */}
-            <span
-              id="landing-eyebrow"
-              className="inline-block font-mono text-xs tracking-[0.08em] uppercase text-[#0e0907]/60 mb-4"
-            >
-              Build a team &middot; Test the hypothetical &middot; Settle the debate
-            </span>
-
-            {/* Hero headline — Space Grotesk display */}
-            <h1
-              id="landing-title"
-              className="font-display text-[clamp(2.5rem,5vw+1rem,4.5rem)] font-bold leading-[1.05] tracking-[-0.02em] text-[#0e0907]"
-              style={{ textWrap: "balance" }}
-            >
-              What if you could
-              <br />
-              prove it?
-            </h1>
-
-            {/* Supporting line — Geist body */}
-            <p
-              id="landing-subtitle"
-              className="mt-5 text-[0.9375rem] leading-relaxed text-[#0e0907]/75 max-w-lg"
-            >
-              Turn any hypothetical team into something you can actually
-              test. Pick the rules. Build it. See how it scores.
-            </p>
-
-            {/* CTAs */}
-            <div id="landing-cta" className="flex items-center gap-3 mt-8">
-              <Link
-                id="landing-cta-lab"
-                href="/lab"
-                className="inline-flex items-center px-5 py-2.5 rounded-md bg-[#0e0907] text-[#ffa05c] text-sm font-medium tracking-[0.01em] transition-all duration-150 hover:bg-[#0e0907]/85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]"
+        <div className="relative max-w-screen-xl mx-auto px-6 py-20 md:py-24 lg:py-28">
+          {/* Two-column editorial layout: copy left, community slideshow right.
+              On mobile the slideshow stacks beneath the headline so the page
+              still reads as a clear value-prop first. */}
+          <div className="grid grid-cols-1 lg:grid-cols-[1.05fr_minmax(0,1fr)] gap-10 lg:gap-14 items-center">
+            {/* Left column — pitch */}
+            <div className="max-w-2xl">
+              {/* Eyebrow label */}
+              <span
+                id="landing-eyebrow"
+                className="inline-block font-mono text-xs tracking-[0.08em] uppercase text-[#0e0907]/60 mb-4"
               >
-                Enter the Lab
-              </Link>
-              <Link
-                id="landing-cta-players"
-                href="/players"
-                className="inline-flex items-center px-5 py-2.5 rounded-md border border-[#0e0907]/25 text-[#0e0907] text-sm font-medium tracking-[0.01em] transition-all duration-150 hover:bg-[#0e0907]/10 hover:border-[#0e0907]/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]"
+                Build a team &middot; Test the hypothetical &middot; Settle the debate
+              </span>
+
+              {/* Hero headline — Space Grotesk display */}
+              <h1
+                id="landing-title"
+                className="font-display text-[clamp(2.5rem,5vw+1rem,4.5rem)] font-bold leading-[1.05] tracking-[-0.02em] text-[#0e0907]"
+                style={{ textWrap: "balance" }}
               >
-                Browse Players
-              </Link>
+                What if you could
+                <br />
+                prove it?
+              </h1>
+
+              {/* Supporting line — Geist body */}
+              <p
+                id="landing-subtitle"
+                className="mt-5 text-[0.9375rem] leading-relaxed text-[#0e0907]/75 max-w-lg"
+              >
+                Turn any hypothetical team into something you can actually
+                test. Pick the rules. Build it. See how it scores.
+              </p>
+
+              {/* CTAs */}
+              <div id="landing-cta" className="flex flex-wrap items-center gap-3 mt-8">
+                <Link
+                  id="landing-cta-lab"
+                  href="/lab"
+                  className="inline-flex items-center px-5 py-2.5 rounded-md bg-[#0e0907] text-[#ffa05c] text-sm font-medium tracking-[0.01em] transition-all duration-150 hover:bg-[#0e0907]/85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]"
+                >
+                  Enter the Lab
+                </Link>
+                <Link
+                  id="landing-cta-players"
+                  href="/players"
+                  className="inline-flex items-center px-5 py-2.5 rounded-md border border-[#0e0907]/25 text-[#0e0907] text-sm font-medium tracking-[0.01em] transition-all duration-150 hover:bg-[#0e0907]/10 hover:border-[#0e0907]/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]"
+                >
+                  Browse Players
+                </Link>
+                <Link
+                  id="landing-cta-faq"
+                  href="/faq"
+                  className="inline-flex items-center text-sm font-medium text-[#0e0907]/75 underline-offset-4 hover:text-[#0e0907] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]"
+                >
+                  How does it work? →
+                </Link>
+              </div>
+            </div>
+
+            {/* Right column — community Teams slideshow */}
+            <div id="landing-hero-slideshow-region" className="w-full">
+              <div className="mb-3 flex items-baseline justify-between">
+                <span className="font-mono text-[0.6875rem] tracking-[0.08em] uppercase text-[#0e0907]/55">
+                  Top community Teams
+                </span>
+                <Link
+                  id="landing-hero-leaderboard-link"
+                  href="/community"
+                  className="font-mono text-[0.6875rem] tracking-[0.04em] text-[#0e0907]/70 underline-offset-4 hover:text-[#0e0907] hover:underline"
+                >
+                  See all →
+                </Link>
+              </div>
+              <HeroSlideshow />
             </div>
           </div>
         </div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,28 +1,6 @@
 import Link from "next/link";
 import { HeroSlideshow } from "@/components/landing/HeroSlideshow";
-
-/* ── Sample data for the proof section ──
-   Hardcoded realistic skill profiles to demonstrate the system visually.
-   These are not fetched; they exist purely to "show, don't tell." */
-
-const SAMPLE_SKILLS = [
-  { name: "Isolation Scorer", tier: "Elite" as const },
-  { name: "Off-Dribble Shooter", tier: "Proficient" as const },
-  { name: "PnR Ball Handler", tier: "Elite" as const },
-  { name: "Driver", tier: "All-Time Great" as const },
-  { name: "Passer", tier: "Proficient" as const },
-  { name: "Versatile Defender", tier: "Capable" as const },
-  { name: "Perimeter Disruptor", tier: "Elite" as const },
-  { name: "Defensive Rebounding", tier: "Capable" as const },
-];
-
-const TIER_STYLES: Record<string, string> = {
-  "All-Time Great": "bg-violet-100 text-violet-800 border-violet-300",
-  Elite: "bg-emerald-100 text-emerald-800 border-emerald-200",
-  Proficient: "bg-sky-100 text-sky-800 border-sky-200",
-  Capable: "bg-amber-100 text-amber-800 border-amber-200",
-  None: "bg-slate-100 text-slate-500 border-slate-200",
-};
+import { ProofCardRotator } from "@/components/landing/ProofCardRotator";
 
 const STEPS = [
   {
@@ -208,58 +186,10 @@ export default function LandingPage() {
             </div>
           </div>
 
-          {/* Right column — sample skill profile card */}
-          <div
-            id="landing-proof-card"
-            className="border border-border rounded-lg bg-card p-6"
-          >
-            {/* Card header — player identity */}
-            <div className="flex items-baseline justify-between mb-5">
-              <div>
-                <h3 className="text-base font-semibold text-foreground">
-                  Sample Player Profile
-                </h3>
-                <span className="text-xs text-muted-foreground">
-                  Guard &middot; 27.4 PPG &middot; 6.2 APG
-                </span>
-              </div>
-              <span className="font-mono text-xs text-muted-foreground tracking-wider">
-                2024-25
-              </span>
-            </div>
-
-            {/* Skill badge grid — the real visual proof */}
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-              {SAMPLE_SKILLS.map((skill) => (
-                <div
-                  key={skill.name}
-                  className="flex flex-col gap-1 p-2.5 rounded-md border border-border bg-background"
-                >
-                  <span className="text-[0.6875rem] font-medium text-muted-foreground leading-tight">
-                    {skill.name}
-                  </span>
-                  <span
-                    className={`inline-flex self-start px-2 py-0.5 text-[0.6875rem] font-medium rounded-sm border ${TIER_STYLES[skill.tier]}`}
-                  >
-                    {skill.tier}
-                  </span>
-                </div>
-              ))}
-            </div>
-
-            {/* Card footer — subtle link */}
-            <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
-              <span className="text-xs text-muted-foreground">
-                8 of 21 skills shown
-              </span>
-              <Link
-                href="/players"
-                className="text-xs font-medium text-[#fe6d34] hover:text-[#fe6d34]/80 transition-colors"
-              >
-                Explore all profiles →
-              </Link>
-            </div>
-          </div>
+          {/* Right column — rotating Skill Profile proof Surface.
+              Sources real Players from the current Snapshot Release pool plus
+              Legends; falls back to a static Sample Player Profile on error. */}
+          <ProofCardRotator />
         </div>
       </section>
 

--- a/frontend/components/landing/HeroSlideshow.tsx
+++ b/frontend/components/landing/HeroSlideshow.tsx
@@ -1,0 +1,501 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight, Pause, Play } from "lucide-react";
+import { getCommunityTeams, listRuleSets } from "@/lib/api";
+import { teamLabelForSize } from "@/lib/builder-config";
+import { cn } from "@/lib/utils";
+import type { CommunityTeamEntry, CommunityTeamPlayer } from "@/lib/types";
+
+/* ── Tunables ── */
+const SLIDE_LIMIT = 6;
+const ADVANCE_MS = 6000;
+const PREVIEW_PLAYERS = 3;
+
+/* ── Helpers ── */
+
+function formatRuleSetName(slug: string): string {
+  return (
+    slug
+      .split("-")
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ") || slug
+  );
+}
+
+function getInitials(name: string): string {
+  const parts = name.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+}
+
+function getShortName(name: string): string {
+  const parts = name.split(/\s+/).filter(Boolean);
+  if (parts.length <= 1) return name;
+  return `${parts[0][0]}. ${parts[parts.length - 1]}`;
+}
+
+/** Order Cornerstone first, then by slot ascending. */
+function orderPlayers(players: CommunityTeamPlayer[]): CommunityTeamPlayer[] {
+  return [...players].sort((a, b) => {
+    if (a.is_cornerstone && !b.is_cornerstone) return -1;
+    if (!a.is_cornerstone && b.is_cornerstone) return 1;
+    return a.slot - b.slot;
+  });
+}
+
+/** Detect prefers-reduced-motion. */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mq.matches);
+    const handler = (event: MediaQueryListEvent) => setReduced(event.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return reduced;
+}
+
+/* ── Player preview (compact) ── */
+
+function PlayerPreview({ player }: { player: CommunityTeamPlayer }) {
+  const initials = getInitials(player.name);
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <div
+        className={cn(
+          "relative flex h-12 w-12 items-end justify-center overflow-hidden rounded-full border-2",
+          player.is_cornerstone
+            ? "border-[#fe6d34] bg-[#fff1e3]"
+            : "border-[#0e0907]/15 bg-[#fff8f0]",
+        )}
+      >
+        {player.nba_api_id ? (
+          <Image
+            src={`https://ak-static.cms.nba.com/wp-content/uploads/headshots/nba/latest/260x190/${player.nba_api_id}.png`}
+            alt=""
+            width={96}
+            height={96}
+            sizes="48px"
+            unoptimized
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <span className="flex h-full w-full items-center justify-center font-mono text-[0.6875rem] font-semibold text-[#0e0907]/75">
+            {initials}
+          </span>
+        )}
+      </div>
+      <span className="max-w-[5rem] truncate text-[0.6875rem] font-medium leading-none text-[#0e0907]/80">
+        {getShortName(player.name)}
+      </span>
+    </div>
+  );
+}
+
+/* ── Slide ── */
+
+interface SlideProps {
+  entry: CommunityTeamEntry;
+  ruleSetLabel: string;
+  active: boolean;
+  index: number;
+  total: number;
+}
+
+function Slide({ entry, ruleSetLabel, active, index, total }: SlideProps) {
+  const ordered = useMemo(() => orderPlayers(entry.players), [entry.players]);
+  const preview = ordered.slice(0, PREVIEW_PLAYERS);
+  const extra = Math.max(0, ordered.length - preview.length);
+  const teamLabel = entry.team_size ? teamLabelForSize(entry.team_size) : null;
+  const score = entry.star_rating;
+
+  return (
+    <Link
+      id={`hero-slideshow-slide-${entry.id}`}
+      href={`/shared/${entry.id}`}
+      role="group"
+      aria-roledescription="slide"
+      aria-label={`Slide ${index + 1} of ${total}: ${entry.name}`}
+      aria-hidden={!active}
+      tabIndex={active ? 0 : -1}
+      className={cn(
+        "group/slide block h-full rounded-lg border border-[#0e0907]/10 bg-[#fff8f0]/95 p-5 shadow-[0_1px_0_0_rgba(14,9,7,0.06),0_8px_24px_-12px_rgba(14,9,7,0.25)] backdrop-blur-sm transition-all duration-200",
+        "hover:border-[#0e0907]/25 hover:shadow-[0_1px_0_0_rgba(14,9,7,0.08),0_12px_28px_-12px_rgba(14,9,7,0.35)]",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]",
+      )}
+    >
+      {/* Header row: rank + score */}
+      <div className="flex items-start justify-between gap-3">
+        <span className="font-mono text-[0.6875rem] font-medium uppercase tracking-[0.08em] text-[#0e0907]/55">
+          #{index + 1} community pick
+        </span>
+        {score != null ? (
+          <span
+            className="inline-flex items-baseline gap-1 rounded-sm bg-[#0e0907] px-2 py-1 font-mono text-[0.8125rem] font-semibold tabular-nums leading-none text-[#ffa05c]"
+            aria-label={`Score ${score.toFixed(1)} out of 5`}
+          >
+            {score.toFixed(1)}
+            <span className="text-[0.625rem] font-normal text-[#ffa05c]/70">/ 5</span>
+          </span>
+        ) : (
+          <span className="font-mono text-[0.75rem] text-[#0e0907]/50">unscored</span>
+        )}
+      </div>
+
+      {/* Team name */}
+      <h3
+        id={`hero-slideshow-slide-${entry.id}-name`}
+        className="mt-3 truncate font-display text-xl font-semibold leading-tight tracking-[-0.01em] text-[#0e0907]"
+      >
+        {entry.name}
+      </h3>
+
+      {/* Meta: Cornerstone / RuleSet */}
+      <p className="mt-1 truncate text-[0.8125rem] leading-snug text-[#0e0907]/65">
+        <span className="font-medium text-[#0e0907]/85">
+          {entry.cornerstone_name !== "-" ? entry.cornerstone_name : "No Cornerstone"}
+        </span>
+        <span aria-hidden className="mx-1.5 text-[#0e0907]/30">·</span>
+        {ruleSetLabel}
+        {teamLabel && (
+          <>
+            <span aria-hidden className="mx-1.5 text-[#0e0907]/30">·</span>
+            {teamLabel}
+          </>
+        )}
+      </p>
+
+      {/* Player preview */}
+      <div className="mt-4 flex items-end gap-3">
+        {preview.map((p) => (
+          <PlayerPreview key={p.player_id ?? p.legend_id ?? `${p.slot}-${p.name}`} player={p} />
+        ))}
+        {extra > 0 && (
+          <div className="flex flex-col items-center gap-1.5">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-dashed border-[#0e0907]/20 bg-transparent font-mono text-[0.75rem] font-medium text-[#0e0907]/55">
+              +{extra}
+            </div>
+            <span className="text-[0.6875rem] text-[#0e0907]/55">more</span>
+          </div>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="mt-5 flex items-center justify-between border-t border-[#0e0907]/10 pt-3">
+        <span className="text-[0.75rem] text-[#0e0907]/60">View this Team</span>
+        <span
+          aria-hidden
+          className="inline-flex items-center font-mono text-[0.75rem] font-medium text-[#0e0907] transition-transform duration-150 group-hover/slide:translate-x-0.5"
+        >
+          →
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+/* ── Skeleton (loading state) ── */
+
+function SlideSkeleton() {
+  return (
+    <div
+      aria-hidden
+      className="h-full rounded-lg border border-[#0e0907]/10 bg-[#fff8f0]/70 p-5"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="h-3 w-24 rounded-sm bg-[#0e0907]/10" />
+        <div className="h-6 w-14 rounded-sm bg-[#0e0907]/15" />
+      </div>
+      <div className="mt-3 h-6 w-3/4 rounded-sm bg-[#0e0907]/15" />
+      <div className="mt-2 h-3 w-1/2 rounded-sm bg-[#0e0907]/10" />
+      <div className="mt-5 flex gap-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex flex-col items-center gap-1.5">
+            <div className="h-12 w-12 rounded-full bg-[#0e0907]/10" />
+            <div className="h-2 w-10 rounded-sm bg-[#0e0907]/10" />
+          </div>
+        ))}
+      </div>
+      <div className="mt-5 h-3 w-1/3 rounded-sm bg-[#0e0907]/10" />
+    </div>
+  );
+}
+
+/* ── Empty State ── */
+
+function EmptyState() {
+  return (
+    <div
+      id="hero-slideshow-empty"
+      className="rounded-lg border border-dashed border-[#0e0907]/25 bg-[#fff8f0]/70 p-6 text-center"
+    >
+      <p className="font-display text-base font-semibold tracking-[-0.01em] text-[#0e0907]">
+        No public Teams yet.
+      </p>
+      <p className="mt-1.5 text-[0.8125rem] leading-relaxed text-[#0e0907]/70">
+        Be the first to build something and share it with the community.
+      </p>
+      <Link
+        id="hero-slideshow-empty-cta"
+        href="/lab"
+        className="mt-4 inline-flex items-center rounded-md bg-[#0e0907] px-4 py-2 text-[0.8125rem] font-medium text-[#ffa05c] transition-colors duration-150 hover:bg-[#0e0907]/85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]"
+      >
+        Build a Team
+      </Link>
+    </div>
+  );
+}
+
+/* ── Main slideshow ── */
+
+interface HeroSlideshowProps {
+  className?: string;
+}
+
+export function HeroSlideshow({ className }: HeroSlideshowProps) {
+  const [teams, setTeams] = useState<CommunityTeamEntry[]>([]);
+  const [ruleSetNameMap, setRuleSetNameMap] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [errored, setErrored] = useState(false);
+  const [active, setActive] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const reducedMotion = usePrefersReducedMotion();
+
+  /* Fetch top public Teams */
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const [teamsRes, ruleSetsRes] = await Promise.all([
+          getCommunityTeams({ sort: "score", page: 1, per_page: SLIDE_LIMIT }),
+          listRuleSets(),
+        ]);
+        if (cancelled) return;
+        if (teamsRes.success && teamsRes.data) {
+          setTeams(teamsRes.data.teams);
+        } else {
+          setErrored(true);
+        }
+        if (ruleSetsRes.success && ruleSetsRes.data) {
+          const map: Record<string, string> = {};
+          for (const rs of ruleSetsRes.data) map[rs.slug] = rs.name;
+          setRuleSetNameMap(map);
+        }
+      } catch {
+        if (!cancelled) setErrored(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const total = teams.length;
+  const shouldAutoAdvance =
+    total > 1 && !paused && !hovered && !focused && !reducedMotion;
+
+  /* Auto-advance */
+  useEffect(() => {
+    if (!shouldAutoAdvance) return;
+    const id = window.setInterval(() => {
+      setActive((prev) => (prev + 1) % total);
+    }, ADVANCE_MS);
+    return () => window.clearInterval(id);
+  }, [shouldAutoAdvance, total]);
+
+  /* Keep active index in range as data loads */
+  useEffect(() => {
+    if (total === 0) return;
+    setActive((prev) => (prev >= total ? 0 : prev));
+  }, [total]);
+
+  const goPrev = useCallback(() => {
+    if (total === 0) return;
+    setActive((prev) => (prev - 1 + total) % total);
+  }, [total]);
+
+  const goNext = useCallback(() => {
+    if (total === 0) return;
+    setActive((prev) => (prev + 1) % total);
+  }, [total]);
+
+  const goTo = useCallback(
+    (idx: number) => {
+      if (total === 0) return;
+      setActive(((idx % total) + total) % total);
+    },
+    [total],
+  );
+
+  /* Keyboard navigation when focus is inside the carousel */
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        goPrev();
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        goNext();
+      }
+    },
+    [goPrev, goNext],
+  );
+
+  /* States */
+  if (loading) {
+    return (
+      <div
+        id="hero-slideshow"
+        className={cn("relative", className)}
+        aria-busy="true"
+        aria-live="polite"
+      >
+        <SlideSkeleton />
+      </div>
+    );
+  }
+
+  if (errored || total === 0) {
+    // Error and Empty States share the same posture: graceful fallback CTA.
+    return (
+      <div id="hero-slideshow" className={cn("relative", className)}>
+        <EmptyState />
+      </div>
+    );
+  }
+
+  const liveLabel = `Showing community Team ${active + 1} of ${total}`;
+
+  return (
+    <div
+      id="hero-slideshow"
+      ref={containerRef}
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="Top community Teams"
+      onKeyDown={onKeyDown}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onFocus={() => setFocused(true)}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setFocused(false);
+        }
+      }}
+      className={cn("relative", className)}
+    >
+      {/* Screen-reader live region for slide changes */}
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        {liveLabel}
+      </span>
+
+      {/* Slide stack — only the active slide is laid out; others stacked beneath for transition */}
+      <div className="relative">
+        {teams.map((entry, i) => {
+          const isActive = i === active;
+          return (
+            <div
+              key={entry.id}
+              className={cn(
+                "transition-opacity duration-300",
+                isActive ? "relative opacity-100" : "pointer-events-none absolute inset-0 opacity-0",
+              )}
+            >
+              <Slide
+                entry={entry}
+                ruleSetLabel={
+                  ruleSetNameMap[entry.ruleset_slug] ?? formatRuleSetName(entry.ruleset_slug)
+                }
+                active={isActive}
+                index={i}
+                total={total}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Controls row */}
+      {total > 1 && (
+        <div className="mt-3 flex items-center justify-between gap-3">
+          {/* Dots */}
+          <div
+            id="hero-slideshow-dots"
+            role="tablist"
+            aria-label="Choose community Team slide"
+            className="flex items-center gap-1.5"
+          >
+            {teams.map((entry, i) => (
+              <button
+                key={entry.id}
+                id={`hero-slideshow-dot-${i}`}
+                type="button"
+                role="tab"
+                aria-selected={i === active}
+                aria-label={`Go to slide ${i + 1}: ${entry.name}`}
+                onClick={() => goTo(i)}
+                className={cn(
+                  "h-1.5 rounded-full transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]",
+                  i === active
+                    ? "w-6 bg-[#0e0907]"
+                    : "w-1.5 bg-[#0e0907]/25 hover:bg-[#0e0907]/45",
+                )}
+              />
+            ))}
+          </div>
+
+          {/* Buttons */}
+          <div className="flex items-center gap-1">
+            <button
+              id="hero-slideshow-pause"
+              type="button"
+              onClick={() => setPaused((p) => !p)}
+              aria-pressed={paused}
+              aria-label={paused ? "Resume slideshow" : "Pause slideshow"}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[#0e0907]/20 bg-[#fff8f0]/70 text-[#0e0907] transition-colors duration-150 hover:border-[#0e0907]/40 hover:bg-[#fff8f0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]"
+            >
+              {paused || reducedMotion ? (
+                <Play className="h-3.5 w-3.5" aria-hidden />
+              ) : (
+                <Pause className="h-3.5 w-3.5" aria-hidden />
+              )}
+            </button>
+            <button
+              id="hero-slideshow-prev"
+              type="button"
+              onClick={goPrev}
+              aria-label="Previous Team"
+              aria-controls="hero-slideshow"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[#0e0907]/20 bg-[#fff8f0]/70 text-[#0e0907] transition-colors duration-150 hover:border-[#0e0907]/40 hover:bg-[#fff8f0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]"
+            >
+              <ChevronLeft className="h-4 w-4" aria-hidden />
+            </button>
+            <button
+              id="hero-slideshow-next"
+              type="button"
+              onClick={goNext}
+              aria-label="Next Team"
+              aria-controls="hero-slideshow"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[#0e0907]/20 bg-[#fff8f0]/70 text-[#0e0907] transition-colors duration-150 hover:border-[#0e0907]/40 hover:bg-[#fff8f0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e0907]"
+            >
+              <ChevronRight className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/landing/ProofCardRotator.tsx
+++ b/frontend/components/landing/ProofCardRotator.tsx
@@ -16,10 +16,14 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { PlayerHeadshot } from "@/components/PlayerHeadshot";
 import { listPlayersWithSkills } from "@/lib/api";
 import { SKILL_LABELS } from "@/lib/skills";
 import { TIER_BADGE_CLASSES, tierToNum } from "@/lib/tiers";
 import type { PlayerWithSkills, SkillTier } from "@/lib/types";
+
+/** Portrait size in px — matches the Saved Team detail Surface (h-12 w-12). */
+const PORTRAIT_SIZE = 48;
 
 /* ── Tunables ── */
 const ROTATE_MS = 5000;
@@ -122,17 +126,24 @@ const FALLBACK_SKILLS: Array<{ label: string; tier: SkillTier }> = [
 function FallbackCard() {
   return (
     <>
-      <div className="flex items-baseline justify-between mb-5">
-        <div>
-          <h3
-            id="landing-proof-card-name"
-            className="text-base font-semibold text-foreground"
-          >
-            Sample Player Profile
-          </h3>
-          <span className="text-xs text-muted-foreground">
-            Guard &middot; 27.4 PPG &middot; 6.2 APG
-          </span>
+      <div className="flex items-center justify-between mb-5 gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <PlayerHeadshot
+            nba_api_id={null}
+            name="Sample Player"
+            size={PORTRAIT_SIZE}
+          />
+          <div className="min-w-0">
+            <h3
+              id="landing-proof-card-name"
+              className="text-base font-semibold text-foreground"
+            >
+              Sample Player Profile
+            </h3>
+            <span className="text-xs text-muted-foreground">
+              Guard &middot; 27.4 PPG &middot; 6.2 APG
+            </span>
+          </div>
         </div>
         <span className="font-mono text-xs text-muted-foreground tracking-wider">
           2024-25
@@ -206,18 +217,25 @@ function LiveCard({ player, fading }: LiveCardProps) {
         transitionDuration: `${FADE_MS}ms`,
       }}
     >
-      <div className="flex items-baseline justify-between mb-5 gap-3">
-        <div className="min-w-0">
-          <h3
-            id="landing-proof-card-name"
-            className="text-base font-semibold text-foreground truncate"
-          >
-            {player.name}
-          </h3>
-          <span className="text-xs text-muted-foreground">{eraChip}</span>
+      <div className="flex items-center justify-between mb-5 gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <PlayerHeadshot
+            nba_api_id={player.nba_api_id ?? null}
+            name={player.name}
+            size={PORTRAIT_SIZE}
+          />
+          <div className="min-w-0">
+            <h3
+              id="landing-proof-card-name"
+              className="text-base font-semibold text-foreground truncate"
+            >
+              {player.name}
+            </h3>
+            <span className="text-xs text-muted-foreground">{eraChip}</span>
+          </div>
         </div>
         <span
-          className={`font-mono text-[0.6875rem] tracking-[0.04em] uppercase px-2 py-0.5 rounded-sm border ${subjectChipClass}`}
+          className={`font-mono text-[0.6875rem] tracking-[0.04em] uppercase px-2 py-0.5 rounded-sm border shrink-0 ${subjectChipClass}`}
         >
           {subjectChip}
         </span>
@@ -344,7 +362,7 @@ export function ProofCardRotator() {
 
   const containerProps = {
     id: "landing-proof-card",
-    className: "border border-border rounded-lg bg-card p-6",
+    className: "relative border border-border rounded-lg bg-card p-6",
     onMouseEnter: () => setPaused(true),
     onMouseLeave: () => setPaused(false),
     onFocusCapture: () => setPaused(true),
@@ -369,9 +387,29 @@ export function ProofCardRotator() {
   }
 
   const player = pool[index];
+  // Preload the next subject's portrait so the cross-fade swap never flashes.
+  const nextPlayer = pool.length > 1 ? pool[(index + 1) % pool.length] : null;
+  const nextHeadshotUrl = nextPlayer?.nba_api_id
+    ? `https://ak-static.cms.nba.com/wp-content/uploads/headshots/nba/latest/260x190/${nextPlayer.nba_api_id}.png`
+    : null;
+
   return (
     <div {...containerProps} aria-live="polite">
       <LiveCard player={player} fading={fading} />
+      {nextHeadshotUrl && (
+        // Warm the browser cache for the upcoming portrait. Hidden from a11y + layout.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={nextHeadshotUrl}
+          alt=""
+          aria-hidden="true"
+          width={1}
+          height={1}
+          loading="eager"
+          decoding="async"
+          className="pointer-events-none absolute h-px w-px opacity-0"
+        />
+      )}
     </div>
   );
 }

--- a/frontend/components/landing/ProofCardRotator.tsx
+++ b/frontend/components/landing/ProofCardRotator.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+/**
+ * ProofCardRotator — landing proof Surface that rotates real Skill Profiles.
+ *
+ * Pool: union of current Snapshot Release Players + Legends, fetched via
+ * listPlayersWithSkills({ include_legends: true }). The component is the
+ * editorial "show, don't tell" Surface for the landing Hero — it surfaces
+ * real Players and Legends with real Skill Tier badges instead of mock copy.
+ *
+ * Motion intent: a slow cross-fade between curated subjects, not a carousel.
+ * Pauses on hover/focus and disables auto-advance under prefers-reduced-motion.
+ * On any error/empty pool the card falls back to a static Sample Player
+ * Profile so the Hero never crashes.
+ */
+
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { listPlayersWithSkills } from "@/lib/api";
+import { SKILL_LABELS } from "@/lib/skills";
+import { TIER_BADGE_CLASSES, tierToNum } from "@/lib/tiers";
+import type { PlayerWithSkills, SkillTier } from "@/lib/types";
+
+/* ── Tunables ── */
+const ROTATE_MS = 5000;
+const FADE_MS = 500;
+const SKILLS_PER_CARD = 6;
+/** Minimum MPG floor so we don't surface fringe rotation Players in the Hero. */
+const MIN_MPG_FOR_PROOF = 20;
+
+/* ── Reduced-motion detection (matches HeroSlideshow convention) ── */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mq.matches);
+    const handler = (event: MediaQueryListEvent) => setReduced(event.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return reduced;
+}
+
+/* ── Helpers ── */
+
+/** Fisher-Yates shuffle for a single randomized rotation order per mount. */
+function shuffle<T>(items: readonly T[]): T[] {
+  const out = items.slice();
+  for (let i = out.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/** Pick the top N Skills by Skill Tier rank (highest first), stable by label. */
+function topSkills(
+  skills: Record<string, string> | null | undefined,
+  limit: number,
+): Array<{ key: string; label: string; tier: SkillTier }> {
+  if (!skills) return [];
+  const ranked = Object.entries(skills)
+    .filter(([, tier]) => tier && tier !== "None")
+    .map(([key, tier]) => ({
+      key,
+      label: SKILL_LABELS[key] ?? key,
+      tier: tier as SkillTier,
+    }))
+    .sort((a, b) => {
+      const diff = tierToNum(b.tier) - tierToNum(a.tier);
+      if (diff !== 0) return diff;
+      return a.label.localeCompare(b.label);
+    });
+  return ranked.slice(0, limit);
+}
+
+/** Format MPG / GP into a single short readout. */
+function formatNumber(value: number | null | undefined, digits = 1): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return value.toFixed(digits);
+}
+
+/** Build a sub-line like "Guard · 2024-25" or "Wing · Legend". */
+function buildEraChip(player: PlayerWithSkills): string {
+  const position = player.position?.trim() || "Player";
+  if (player.is_legend) {
+    if (player.peak_year) {
+      const peakSeason = `${player.peak_year}-${String((player.peak_year + 1) % 100).padStart(2, "0")}`;
+      return `${position} · Peak ${peakSeason}`;
+    }
+    return `${position} · Legend`;
+  }
+  return `${position} · ${player.season}`;
+}
+
+/** Decide whether a subject is suitable for the rotation (has real Skills). */
+function isEligible(player: PlayerWithSkills): boolean {
+  if (!player.skills) return false;
+  const eliteCount = Object.values(player.skills).filter(
+    (tier) => tier === "Elite" || tier === "All-Time Great",
+  ).length;
+  if (eliteCount === 0) return false;
+  if (player.is_legend) return true;
+  // For active Players, require a real rotation role.
+  return (player.minutes_per_game ?? 0) >= MIN_MPG_FOR_PROOF;
+}
+
+/* ── Static fallback (matches original mock copy) ── */
+
+const FALLBACK_SKILLS: Array<{ label: string; tier: SkillTier }> = [
+  { label: "Isolation Scorer", tier: "Elite" },
+  { label: "Off-Dribble Shooter", tier: "Proficient" },
+  { label: "PnR Ball Handler", tier: "Elite" },
+  { label: "Driver", tier: "All-Time Great" },
+  { label: "Passer", tier: "Proficient" },
+  { label: "Versatile Defender", tier: "Capable" },
+  { label: "Perimeter Disruptor", tier: "Elite" },
+  { label: "Defensive Rebounding", tier: "Capable" },
+];
+
+function FallbackCard() {
+  return (
+    <>
+      <div className="flex items-baseline justify-between mb-5">
+        <div>
+          <h3
+            id="landing-proof-card-name"
+            className="text-base font-semibold text-foreground"
+          >
+            Sample Player Profile
+          </h3>
+          <span className="text-xs text-muted-foreground">
+            Guard &middot; 27.4 PPG &middot; 6.2 APG
+          </span>
+        </div>
+        <span className="font-mono text-xs text-muted-foreground tracking-wider">
+          2024-25
+        </span>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {FALLBACK_SKILLS.map((skill) => (
+          <div
+            key={skill.label}
+            className="flex flex-col gap-1 p-2.5 rounded-md border border-border bg-background"
+          >
+            <span className="text-[0.6875rem] font-medium text-muted-foreground leading-tight">
+              {skill.label}
+            </span>
+            <span
+              className={`inline-flex self-start px-2 py-0.5 text-[0.6875rem] font-medium rounded-sm ${TIER_BADGE_CLASSES[skill.tier]}`}
+            >
+              {skill.tier}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">
+          8 of 21 skills shown
+        </span>
+        <Link
+          id="landing-proof-card-cta"
+          href="/players"
+          className="text-xs font-medium text-[#fe6d34] hover:text-[#fe6d34]/80 transition-colors"
+        >
+          Explore all profiles →
+        </Link>
+      </div>
+    </>
+  );
+}
+
+/* ── Live card ── */
+
+interface LiveCardProps {
+  player: PlayerWithSkills;
+  fading: boolean;
+}
+
+function LiveCard({ player, fading }: LiveCardProps) {
+  const skills = useMemo(
+    () => topSkills(player.skills, SKILLS_PER_CARD),
+    [player.skills],
+  );
+  const totalRated = useMemo(
+    () =>
+      player.skills
+        ? Object.values(player.skills).filter((tier) => tier && tier !== "None")
+            .length
+        : 0,
+    [player.skills],
+  );
+  const eraChip = buildEraChip(player);
+
+  const subjectChip = player.is_legend ? "Legend" : "Current Snapshot";
+  const subjectChipClass = player.is_legend
+    ? "bg-violet-50 text-violet-700 border-violet-200"
+    : "bg-[#fe6d34]/10 text-[#fe6d34] border-[#fe6d34]/30";
+
+  return (
+    <div
+      className="transition-opacity"
+      style={{
+        opacity: fading ? 0 : 1,
+        transitionDuration: `${FADE_MS}ms`,
+      }}
+    >
+      <div className="flex items-baseline justify-between mb-5 gap-3">
+        <div className="min-w-0">
+          <h3
+            id="landing-proof-card-name"
+            className="text-base font-semibold text-foreground truncate"
+          >
+            {player.name}
+          </h3>
+          <span className="text-xs text-muted-foreground">{eraChip}</span>
+        </div>
+        <span
+          className={`font-mono text-[0.6875rem] tracking-[0.04em] uppercase px-2 py-0.5 rounded-sm border ${subjectChipClass}`}
+        >
+          {subjectChip}
+        </span>
+      </div>
+
+      {/* Real stat readouts — MPG, GP, and rated-skill density. */}
+      <div className="flex gap-6 mb-5">
+        <div className="flex flex-col gap-0.5">
+          <span className="font-mono text-[0.625rem] font-medium tracking-[0.04em] uppercase text-muted-foreground">
+            MPG
+          </span>
+          <span className="font-mono text-sm tabular-nums text-foreground">
+            {formatNumber(player.minutes_per_game)}
+          </span>
+        </div>
+        <div className="flex flex-col gap-0.5">
+          <span className="font-mono text-[0.625rem] font-medium tracking-[0.04em] uppercase text-muted-foreground">
+            GP
+          </span>
+          <span className="font-mono text-sm tabular-nums text-foreground">
+            {player.games_played ?? "—"}
+          </span>
+        </div>
+        <div className="flex flex-col gap-0.5">
+          <span className="font-mono text-[0.625rem] font-medium tracking-[0.04em] uppercase text-muted-foreground">
+            Skills Rated
+          </span>
+          <span className="font-mono text-sm tabular-nums text-foreground">
+            {totalRated}/21
+          </span>
+        </div>
+      </div>
+
+      {/* Skill chips — real Skill Tier badge styling. */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        {skills.map((skill) => (
+          <div
+            key={skill.key}
+            className="flex flex-col gap-1 p-2.5 rounded-md border border-border bg-background"
+          >
+            <span className="text-[0.6875rem] font-medium text-muted-foreground leading-tight">
+              {skill.label}
+            </span>
+            <span
+              className={`inline-flex self-start px-2 py-0.5 text-[0.6875rem] font-medium rounded-sm ${TIER_BADGE_CLASSES[skill.tier]}`}
+            >
+              {skill.tier}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">
+          {skills.length} of 21 skills shown
+        </span>
+        <Link
+          id="landing-proof-card-cta"
+          href={`/players/${player.id}`}
+          className="text-xs font-medium text-[#fe6d34] hover:text-[#fe6d34]/80 transition-colors"
+        >
+          See full profile →
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+/* ── Rotator (default export) ── */
+
+export function ProofCardRotator() {
+  const [pool, setPool] = useState<PlayerWithSkills[] | null>(null);
+  const [errored, setErrored] = useState(false);
+  const [index, setIndex] = useState(0);
+  const [fading, setFading] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const reducedMotion = usePrefersReducedMotion();
+  const cancelledRef = useRef(false);
+
+  // Load Snapshot Players + Legends once per mount.
+  useEffect(() => {
+    cancelledRef.current = false;
+    listPlayersWithSkills()
+      .then((res) => {
+        if (cancelledRef.current) return;
+        if (!res.success || !res.data) {
+          setErrored(true);
+          return;
+        }
+        const eligible = res.data.filter(isEligible);
+        if (eligible.length === 0) {
+          setErrored(true);
+          return;
+        }
+        setPool(shuffle(eligible));
+      })
+      .catch(() => {
+        if (!cancelledRef.current) setErrored(true);
+      });
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, []);
+
+  // Auto-advance with fade. Skip entirely under reduced motion or while paused.
+  useEffect(() => {
+    if (!pool || pool.length <= 1) return;
+    if (reducedMotion || paused) return;
+
+    let swap: number | undefined;
+    const tick = window.setTimeout(() => {
+      setFading(true);
+      swap = window.setTimeout(() => {
+        setIndex((i) => (i + 1) % pool.length);
+        setFading(false);
+      }, FADE_MS);
+    }, ROTATE_MS);
+
+    return () => {
+      window.clearTimeout(tick);
+      if (swap !== undefined) window.clearTimeout(swap);
+    };
+  }, [pool, index, paused, reducedMotion]);
+
+  const containerProps = {
+    id: "landing-proof-card",
+    className: "border border-border rounded-lg bg-card p-6",
+    onMouseEnter: () => setPaused(true),
+    onMouseLeave: () => setPaused(false),
+    onFocusCapture: () => setPaused(true),
+    onBlurCapture: () => setPaused(false),
+  };
+
+  if (errored || (pool && pool.length === 0)) {
+    return (
+      <div {...containerProps}>
+        <FallbackCard />
+      </div>
+    );
+  }
+
+  if (!pool) {
+    // Loading — render the fallback so layout stays stable and Hero never crashes.
+    return (
+      <div {...containerProps} aria-busy="true">
+        <FallbackCard />
+      </div>
+    );
+  }
+
+  const player = pool[index];
+  return (
+    <div {...containerProps} aria-live="polite">
+      <LiveCard player={player} fading={fading} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Landing Hero now shows the top public community Teams as an accessible slideshow next to the headline, inspired by Basketball GM's screenshot carousel pattern. The Lab remains the primary CTA; a clear FAQ link is added from the Hero to close the discoverability gap from #19.

- New `HeroSlideshow` client component fetches the top 6 public Saved Teams via the existing `/api/community/teams?sort=score` endpoint (introduced in #14) and renders each as a slide with Team name, Cornerstone, RuleSet, score badge, and a compact Player preview (Cornerstone-first, `+N more`).
- Slides link to `/shared/<id>` so a visitor can click straight through to the shared Saved Team detail.
- Hero becomes a two-column editorial grid on desktop and stacks on mobile so the value-prop still reads first on small screens.

## Design rationale

- **Anti-template.** The slide is editorial: dark monospaced score badge against the amber Hero, dashed `+N` cluster, hairline dividers, and an arrow that nudges on hover. No off-the-shelf carousel look.
- **Honest Signifiers + Transparent Friction.** Pause button, dot count, and prev/next are all visible affordances. Auto-advance pauses on hover/focus and is automatically off under `prefers-reduced-motion`.
- **Accessibility.** `role="region"` + `aria-roledescription="carousel"`, labelled prev/next/pause/dot controls, ArrowLeft/ArrowRight keyboard nav, slide tab-order follows the active slide, and a screen-reader live region announces slide changes.
- **Empty State / Error State.** No public Teams or a fetch failure both fall back to the same intentional CTA card ("Be the first to build something and share it"), not a crash or blank.
- **Loading State.** Skeleton slide, not a spinner.
- **Stable ids.** `hero-slideshow`, `hero-slideshow-prev`, `hero-slideshow-next`, `hero-slideshow-pause`, `hero-slideshow-dot-N`, `hero-slideshow-slide-<id>`, plus `landing-cta-faq` and `landing-hero-leaderboard-link`.

Closes #29.

## Test plan

- [ ] Visit `/` on desktop: slideshow renders to the right of the headline, auto-advances every 6s, pauses on hover/focus
- [ ] Click a slide: routes to `/shared/<id>`
- [ ] prev / next buttons cycle correctly and wrap at the ends
- [ ] Dot buttons jump directly to that slide and reflect `aria-selected`
- [ ] Pause button toggles auto-advance; icon switches Pause <-> Play
- [ ] Tab into the slideshow region, press ArrowLeft / ArrowRight to navigate
- [ ] System reduced-motion ON: slideshow does not auto-advance and pause icon shows Play
- [ ] Empty / error path: temporarily blocking the endpoint shows the fallback "Be the first to build" CTA, not a crash
- [ ] Responsive: 320 / 768 / 1024 / 1440 widths — copy stacks above slideshow on mobile, side-by-side on `lg`
- [ ] `landing-cta-faq` links to `/faq` and `landing-hero-leaderboard-link` links to `/community`
- [ ] `npm run lint` passes (verified)