### PR TITLE
feat(evaluation-versions): harden composite_coefficients publish gate (#45, #46)

### DIFF
--- a/backend/services/evaluation_versions/validator.py
+++ b/backend/services/evaluation_versions/validator.py
@@ -7,23 +7,31 @@ Checks structural integrity before a draft can be published:
   L3 — formula_refs ↔ Impact Trait consistency (orphan refs block publish)
   L4 — Skills referenced by handlers exist in taxonomy
   L5 — orphan Impact Traits with no formula_ref (warning, does not block)
+  L6 — composite_coefficients keys must be in the COMPOSITE_COEFFICIENTS
+       allowlist (warning — supports staged migrations where the key lands
+       before the formula that consumes it)
   L7 — changelog note is non-empty
   L8 — composite_formulas structural integrity (when present)
+  L9 — composite_coefficients values must be finite numbers (error —
+       non-finite values silently propagate through the composite pipeline
+       and poison every downstream rating)
 """
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
 from services.cohesion_engine.engine import CohesionEngine
+from services.cohesion_engine.weights import COMPOSITE_COEFFICIENTS
 
 
 @dataclass(frozen=True)
 class PublishGateViolation:
     """One structural issue found during publish gate validation."""
 
-    layer: str           # 'L1' | 'L2' | 'L3' | 'L4' | 'L5' | 'L7' | 'L8'
+    layer: str           # 'L1' | 'L2' | 'L3' | 'L4' | 'L5' | 'L6' | 'L7' | 'L8' | 'L9'
     code: str            # machine-readable error code
     message: str         # human-readable explanation
     target: str = ""     # optional path to the offending field
@@ -215,6 +223,9 @@ def validate(
             target="taxonomy.skills",
         ))
 
+    # L6 + L9: composite_coefficients allowlist + non-finite checks
+    violations.extend(_validate_composite_coefficients(values))
+
     # L7: changelog note non-empty
     if not changelog_note or not changelog_note.strip():
         violations.append(PublishGateViolation(
@@ -228,6 +239,73 @@ def validate(
     composite_formulas = values.get("composite_formulas")
     if composite_formulas and isinstance(composite_formulas, dict):
         violations.extend(_validate_composite_formulas(composite_formulas))
+
+    return violations
+
+
+def _validate_composite_coefficients(
+    values: dict[str, Any],
+) -> list[PublishGateViolation]:
+    """Validate the ``composite_coefficients`` block.
+
+    L6 (warning): every key must be in the ``COMPOSITE_COEFFICIENTS`` allowlist
+    from ``services.cohesion_engine.weights``. Unknown keys persist invisibly
+    and create silent-drift risk (see #46).
+
+    L9 (error): every value must be a finite number (``math.isfinite``).
+    Non-finite values (``inf``, ``-inf``, ``NaN``) propagate silently through
+    the composite pipeline, poisoning every downstream rating (see #45). Bool
+    values are rejected as non-numeric because ``bool`` is an ``int`` subclass
+    in Python and would otherwise slip past the type check.
+    """
+    violations: list[PublishGateViolation] = []
+
+    coefficients = values.get("composite_coefficients")
+    if not isinstance(coefficients, dict):
+        # Absence/shape is enforced by L2; nothing to scan without a mapping.
+        return violations
+
+    allowlist = set(COMPOSITE_COEFFICIENTS.keys())
+
+    for key, value in coefficients.items():
+        # L6 — unknown key (warning, does not block publish)
+        if key not in allowlist:
+            violations.append(PublishGateViolation(
+                layer="L6",
+                code="coefficient_key_unknown",
+                message=(
+                    f"composite_coefficients key '{key}' is not in the "
+                    f"COMPOSITE_COEFFICIENTS allowlist. Remove the orphan "
+                    f"key or add it to services/cohesion_engine/weights.py."
+                ),
+                target=f"values.composite_coefficients.{key}",
+                severity="warning",
+            ))
+
+        # L9 — non-numeric or non-finite value (error, blocks publish)
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            violations.append(PublishGateViolation(
+                layer="L9",
+                code="coefficient_value_non_numeric",
+                message=(
+                    f"composite_coefficients['{key}'] must be a finite "
+                    f"number, got {type(value).__name__} ({value!r})."
+                ),
+                target=f"values.composite_coefficients.{key}",
+                severity="error",
+            ))
+        elif not math.isfinite(value):
+            violations.append(PublishGateViolation(
+                layer="L9",
+                code="coefficient_value_non_finite",
+                message=(
+                    f"composite_coefficients['{key}'] must be finite, "
+                    f"got {value!r}. Non-finite coefficients silently "
+                    f"corrupt every downstream composite."
+                ),
+                target=f"values.composite_coefficients.{key}",
+                severity="error",
+            ))
 
     return violations
 

--- a/backend/tests/test_evaluation_versions/test_validator.py
+++ b/backend/tests/test_evaluation_versions/test_validator.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
 import pytest
 
+from services.cohesion_engine.weights import COMPOSITE_COEFFICIENTS
 from services.evaluation_versions.validator import validate
 
 
@@ -17,10 +19,12 @@ def _load_v1_payload() -> dict:
 
 
 class TestValidatorHappyPath:
-    def test_v1_payload_is_valid(self):
+    def test_v1_payload_has_no_blocking_errors(self):
+        """Seed payload must publish cleanly. Warnings are tolerated (see L6)."""
         payload = _load_v1_payload()
         violations = validate(payload, "test changelog note")
-        assert violations == []
+        blocking = [v for v in violations if v.severity == "error"]
+        assert blocking == [], f"Unexpected blocking violations: {blocking}"
 
 
 class TestL1HandlerExistence:
@@ -111,3 +115,143 @@ class TestL7ChangelogNote:
         violations = validate(payload, "   ")
         l7 = [v for v in violations if v.layer == "L7"]
         assert len(l7) == 1
+
+
+class TestL6CompositeCoefficientsAllowlist:
+    """Issue #46 — composite_coefficients keys must be in the allowlist."""
+
+    def test_unknown_key_emits_warning(self):
+        payload = _load_v1_payload()
+        payload["values"]["composite_coefficients"]["ghost_coefficient"] = 0.5
+        violations = validate(payload, "note")
+        l6 = [v for v in violations if v.layer == "L6" and "ghost_coefficient" in v.target]
+        assert len(l6) == 1
+        assert l6[0].code == "coefficient_key_unknown"
+        assert l6[0].severity == "warning"
+        assert "ghost_coefficient" in l6[0].message
+        assert l6[0].target == "values.composite_coefficients.ghost_coefficient"
+
+    def test_unknown_key_does_not_block_publish(self):
+        """Severity must be 'warning' so staged migrations still ship."""
+        payload = _load_v1_payload()
+        payload["values"]["composite_coefficients"]["future_key"] = 0.1
+        violations = validate(payload, "note")
+        blocking = [v for v in violations if v.severity == "error"]
+        assert blocking == []
+
+    def test_multiple_unknown_keys_each_flagged(self):
+        payload = _load_v1_payload()
+        payload["values"]["composite_coefficients"]["orphan_a"] = 0.1
+        payload["values"]["composite_coefficients"]["orphan_b"] = 0.2
+        violations = validate(payload, "note")
+        l6 = [v for v in violations if v.layer == "L6"]
+        targets = {v.target for v in l6}
+        assert "values.composite_coefficients.orphan_a" in targets
+        assert "values.composite_coefficients.orphan_b" in targets
+
+    def test_empty_dict_passes_silently(self):
+        """Zero coefficients should produce no L6 or L9 violations — empty is a valid state."""
+        payload = _load_v1_payload()
+        payload["values"]["composite_coefficients"] = {}
+        violations = validate(payload, "note")
+        related = [v for v in violations if v.layer in ("L6", "L9")]
+        assert related == []
+
+    def test_seed_drift_is_surfaced_as_warning(self):
+        """Document and lock in the orphan-drift case L6 was built to catch.
+
+        The v1 seed contains transition_passer_scale (a coefficient that the
+        formula engine stopped consuming during the #43 audit). It still lives
+        in the seed JSON, so L6 must surface it as a warning. This test exists
+        so a future seed cleanup deliberately removes both sides instead of
+        silently regressing the safety net.
+        """
+        payload = _load_v1_payload()
+        seed_keys = set(payload["values"]["composite_coefficients"].keys())
+        drift = seed_keys - set(COMPOSITE_COEFFICIENTS.keys())
+        if not drift:
+            pytest.skip("Seed and allowlist now match — happy day. Update this test.")
+        violations = validate(payload, "note")
+        l6_targets = {v.target for v in violations if v.layer == "L6"}
+        for orphan in drift:
+            assert f"values.composite_coefficients.{orphan}" in l6_targets
+
+
+class TestL9CompositeCoefficientsFinite:
+    """Issue #45 — composite_coefficients values must be finite numbers."""
+
+    @pytest.mark.parametrize("bad_value", [
+        float("inf"),
+        float("-inf"),
+        float("nan"),
+    ])
+    def test_non_finite_value_blocks_publish(self, bad_value):
+        payload = _load_v1_payload()
+        payload["values"]["composite_coefficients"]["spacing_off_dribble"] = bad_value
+        violations = validate(payload, "note")
+        l9 = [v for v in violations if v.layer == "L9"]
+        assert len(l9) == 1
+        assert l9[0].code == "coefficient_value_non_finite"
+        assert l9[0].severity == "error"
+        assert l9[0].target == "values.composite_coefficients.spacing_off_dribble"
+        assert "spacing_off_dribble" in l9[0].message
+
+    @pytest.mark.parametrize("field", [
+        "spacing_off_dribble",                      # plain coefficient
+        "paint_touch_finishing_scale",              # amplifier scale
+        "perimeter_defense_versatile_defender",     # multi-skill weight
+        "pnr_screener_secondary_scale",             # another amplifier scale
+    ])
+    def test_non_finite_per_known_field(self, field):
+        """Every known coefficient field must reject non-finite values."""
+        assert field in COMPOSITE_COEFFICIENTS, (
+            f"Test fixture drift: {field} no longer in COMPOSITE_COEFFICIENTS. "
+            f"Pick a different real key."
+        )
+        payload = _load_v1_payload()
+        payload["values"]["composite_coefficients"][field] = float("inf")
+        violations = validate(payload, "note")
+        l9 = [v for v in violations if v.layer == "L9" and field in v.target]
+        assert l9, f"Validator did not catch non-finite value at {field}"
+
+    def test_non_numeric_value_blocks_publish(self):
+        payload = _load_v1_payload()
+        payload["values"]["composite_coefficients"]["spacing_off_dribble"] = "0.5"
+        violations = validate(payload, "note")
+        l9 = [v for v in violations if v.layer == "L9"]
+        assert len(l9) == 1
+        assert l9[0].code == "coefficient_value_non_numeric"
+        assert l9[0].severity == "error"
+
+    def test_bool_value_blocks_publish(self):
+        """``True`` is an ``int`` subclass; reject so callers cannot smuggle flags here."""
+        payload = _load_v1_payload()
+        payload["values"]["composite_coefficients"]["spacing_off_dribble"] = True
+        violations = validate(payload, "note")
+        l9 = [v for v in violations if v.layer == "L9"]
+        assert len(l9) == 1
+        assert l9[0].code == "coefficient_value_non_numeric"
+
+    def test_finite_zero_value_passes(self):
+        payload = _load_v1_payload()
+        payload["values"]["composite_coefficients"]["spacing_off_dribble"] = 0.0
+        violations = validate(payload, "note")
+        l9 = [v for v in violations if v.layer == "L9"]
+        assert l9 == []
+
+    def test_jsonb_roundtrip_non_finite_caught_at_validator(self):
+        """A non-finite value that survived a JSON serialize/deserialize cycle
+        must still be caught by the validator before reaching the DB layer.
+
+        Python's json module accepts ``Infinity``/``NaN`` literals when the
+        default ``parse_constant`` is used; the validator is the last line of
+        defense before Supabase JSONB persistence.
+        """
+        payload = _load_v1_payload()
+        payload["values"]["composite_coefficients"]["spacing_off_dribble"] = float("inf")
+        roundtripped = json.loads(json.dumps(payload))
+        assert math.isinf(roundtripped["values"]["composite_coefficients"]["spacing_off_dribble"])
+        violations = validate(roundtripped, "note")
+        l9 = [v for v in violations if v.layer == "L9"]
+        assert len(l9) == 1
+        assert l9[0].severity == "error"


### PR DESCRIPTION
Closes #45
Closes #46

## Summary

Two new structural checks on the Evaluation Version publish gate validator.

**L6 (warning) — #46 allowlist**: every key in \`values.composite_coefficients\` must exist in \`COMPOSITE_COEFFICIENTS\` (services/cohesion_engine/weights.py). Warning severity so staged migrations (add key now, wire formula later) still publish. Catches orphan drift like the \`transition_passer_scale\` finding from the #43 audit.

**L9 (error) — #45 finite values**: every value in \`composite_coefficients\` must be a finite number (\`math.isfinite\`). Inf, -inf, NaN propagate silently through the composite pipeline and poison every downstream rating; JSON deserialization accepts them, so the validator is the last line of defense before Supabase JSONB persistence. Also rejects non-numeric and \`bool\` (because \`bool\` is an \`int\` subclass in Python).

The current v1 seed has known orphan drift (\`transition_passer_scale\` lives in seed, dropped from weights.py during #43). Happy-path test now asserts no blocking errors rather than zero violations, and \`test_seed_drift_is_surfaced_as_warning\` locks in the case so a future seed cleanup is deliberate.

## Test plan

- [x] 15 new tests in \`test_validator.py\` — parametrized inf/-inf/NaN, per-field coverage on real coefficient keys, non-numeric, bool, empty-dict, JSONB round-trip, seed-drift lockdown
- [x] Full \`pytest tests/test_evaluation_versions/\` — 35 pass
- [x] Manual smoke: try publishing a draft with \`spacing_off_dribble: float('inf')\` via the calibration UI, confirm \`publish_gate_failed\` with the L9 violation
- [x] Manual smoke: publish a draft with an injected unknown key, confirm publish succeeds (warning only)

## Notes

Layer numbering: agent originally used L6 + L8, but main's L8 slot was claimed by \`composite_formulas\` structural integrity in #43. Renumbered to L6 + L9 during cherry-pick. Adapted from worktree commit \`146c2c6\` (originally based on pre-#43 main) with review fixes applied (explicit \`severity="error"\` on L9, real coefficient key names in parametrized tests, empty-dict coverage).