### PR TITLE
refactor(snapshot-versions): rename working tables for draft/released clarity

### DIFF
--- a/backend/api/calibration.py
+++ b/backend/api/calibration.py
@@ -191,7 +191,7 @@ def _validate_threshold_rule(rule: dict) -> str | None:
 @require_admin
 def get_all_thresholds():
     """
-    Return all skill threshold rules from the skill_thresholds table.
+    Return all skill threshold rules from the draft_skill_thresholds table.
     Includes the full JSONB blob (volume gates, tier conditions, stabilization
     config, tier bumps, pre-adjustments, auto-promotions, stat_confidence, etc.).
 
@@ -200,7 +200,7 @@ def get_all_thresholds():
     try:
         supabase = get_supabase()
         rows = (
-            supabase.table("skill_thresholds")
+            supabase.table("draft_skill_thresholds")
             .select("id, skill_name, thresholds, updated_at")
             .order("skill_name")
             .execute()
@@ -244,7 +244,7 @@ def upsert_threshold(skill_name: str):
         supabase = get_supabase()
 
         # Upsert on skill_name conflict — insert if new, update if exists
-        supabase.table("skill_thresholds").upsert(
+        supabase.table("draft_skill_thresholds").upsert(
             {"skill_name": skill_name, "thresholds": body},
             on_conflict="skill_name",
         ).execute()

--- a/backend/api/cohesion_calibration.py
+++ b/backend/api/cohesion_calibration.py
@@ -109,7 +109,7 @@ def _fetch_player_with_skills(player_id: str) -> dict | None:
         player = legend_res.data[0]
         # Fetch legend skill profile (manual source)
         profile_res = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("profile")
             .eq("legend_id", player_id)
             .eq("is_legend", True)
@@ -121,7 +121,7 @@ def _fetch_player_with_skills(player_id: str) -> dict | None:
         player = player_res.data[0]
         # Fetch composite skill profile for current players
         profile_res = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("profile")
             .eq("player_id", player_id)
             .eq("source", "composite")
@@ -873,12 +873,12 @@ def distribution_preview() -> tuple:
     raw_values: list[float] = []
 
     for source_query in [
-        lambda: client.table("skill_profiles")
+        lambda: client.table("draft_skill_profiles")
             .select("profile")
             .eq("season", CURRENT_SEASON)
             .eq("source", "composite")
             .execute(),
-        lambda: client.table("skill_profiles")
+        lambda: client.table("draft_skill_profiles")
             .select("profile")
             .eq("source", "manual")
             .eq("is_legend", True)

--- a/backend/api/composite.py
+++ b/backend/api/composite.py
@@ -75,12 +75,12 @@ def _get_stat_skills(player_id: str, season: str, supabase: Client) -> dict:
     """
     Fetch the stat-based skill profile.
 
-    First tries the skill_profiles DB cache (source='stats'). If not found,
+    First tries the draft_skill_profiles DB cache (source='stats'). If not found,
     computes fresh via the skill mapping service and persists it.
     """
     try:
         row = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("profile")
             .eq("player_id", player_id)
             .eq("season", season)
@@ -197,7 +197,7 @@ def composite_profile_endpoint(player_id: str):
       2. Compute notability score
       3. Run Claude assessment (14 skills)
       4. Composite all 19 skills
-      5. Persist stats / claude / composite skill_profiles and skill_flags
+      5. Persist stats / claude / composite draft_skill_profiles and draft_skill_flags
 
     Path params:
       player_id — Supabase UUID

--- a/backend/api/legends.py
+++ b/backend/api/legends.py
@@ -7,7 +7,7 @@ Endpoints:
   PUT  /api/legends/<legend_id>/skills           — upsert partial skill profile
   POST /api/legends/<legend_id>/claude-suggestion — Claude's suggestions (not persisted)
 
-Legend skill profiles are stored in skill_profiles with:
+Legend skill profiles are stored in draft_skill_profiles with:
   is_legend=true, source='manual', season=NULL, legend_id=<legend uuid>
   player_id is left NULL for legend rows.
 
@@ -134,7 +134,7 @@ def list_legends():
         # Fetch all legend skill profiles in one query (is_legend=true, source=manual)
         # We only need legend_id and the profile JSONB for completion counting
         profiles_res = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("legend_id, profile")
             .eq("is_legend", True)
             .eq("source", "manual")
@@ -211,7 +211,7 @@ def get_legend(legend_id: str):
 
         # Fetch skill profile (manual legend profile)
         profile_res = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id, profile")
             .eq("legend_id", legend_id)
             .eq("is_legend", True)
@@ -311,7 +311,7 @@ def update_legend_skills(legend_id: str):
 
         # Fetch existing profile to merge (partial update support)
         existing_res = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id, profile")
             .eq("legend_id", legend_id)
             .eq("is_legend", True)
@@ -326,7 +326,7 @@ def update_legend_skills(legend_id: str):
             merged_profile = {**existing_profile, **incoming_profile}
             # Update the existing row
             (
-                supabase.table("skill_profiles")
+                supabase.table("draft_skill_profiles")
                 .update({"profile": merged_profile})
                 .eq("id", existing_res.data[0]["id"])
                 .execute()
@@ -335,7 +335,7 @@ def update_legend_skills(legend_id: str):
             # Create a new profile row (upsert via insert)
             merged_profile = {**_empty_profile(), **incoming_profile}
             (
-                supabase.table("skill_profiles")
+                supabase.table("draft_skill_profiles")
                 .insert({
                     "legend_id":  legend_id,
                     "is_legend":  True,
@@ -635,7 +635,7 @@ def claude_suggestion(legend_id: str):
 
         # Fetch existing skill profile (if any) — used to build diff context for Claude
         profile_res = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("profile")
             .eq("legend_id", legend_id)
             .eq("is_legend", True)

--- a/backend/api/pipeline.py
+++ b/backend/api/pipeline.py
@@ -92,7 +92,7 @@ def pipeline_status():
         players_with_stats = len(set(r["player_id"] for r in (stats_rows.data or [])))
 
         skills_profiles = run_query(lambda: (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("player_id")
             .eq("season", season)
             .eq("source", "stats")
@@ -101,7 +101,7 @@ def pipeline_status():
         players_with_skills = len(set(r["player_id"] for r in (skills_profiles.data or [])))
 
         composite_profiles = run_query(lambda: (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id, player_id")
             .eq("season", season)
             .eq("source", "composite")
@@ -122,7 +122,7 @@ def pipeline_status():
         for i in range(0, len(composite_ids), _CHUNK):
             chunk = composite_ids[i: i + _CHUNK]
             unresolved = run_query(lambda c=chunk: (
-                supabase.table("skill_flags")
+                supabase.table("draft_skill_flags")
                 .select("id, skill_profile_id")
                 .in_("skill_profile_id", c)
                 .is_("resolution", "null")
@@ -135,7 +135,7 @@ def pipeline_status():
                     flagged_player_ids.add(pid)
 
             all_flags = run_query(lambda c=chunk: (
-                supabase.table("skill_flags")
+                supabase.table("draft_skill_flags")
                 .select("id")
                 .in_("skill_profile_id", c)
                 .execute()

--- a/backend/api/players.py
+++ b/backend/api/players.py
@@ -458,7 +458,7 @@ def _fetch_legends_for_bulk() -> list:
     """
     Return legends that have at least one rated skill, shaped as PlayerWithSkills dicts.
 
-    Legends are identified by is_legend=True, source='manual' in skill_profiles.
+    Legends are identified by is_legend=True, source='manual' in draft_skill_profiles.
     Skills are condensed to { skill_name: tier_string } — same shape as current players.
     Nulls (unrated skills) are omitted; 'None' tiers are kept to match current-player parity.
     """
@@ -479,7 +479,7 @@ def _fetch_legends_for_bulk() -> list:
 
     # Fetch manual skill profiles for all legends in one query
     profiles_res = (
-        supabase.table("skill_profiles")
+        supabase.table("draft_skill_profiles")
         .select("legend_id, profile")
         .in_("legend_id", legend_ids)
         .eq("is_legend", True)
@@ -533,7 +533,7 @@ def _fetch_legends_for_bulk() -> list:
 def _fetch_bulk_players(season: str, min_mpg: float) -> list:
     """
     Execute all three Supabase queries needed for the bulk players response
-    (players → skill_profiles → skill_flags) and join them in Python.
+    (players → draft_skill_profiles → draft_skill_flags) and join them in Python.
 
     Isolated into a standalone function so the route handler can retry the
     entire sequence on an HTTP/2 connection reset (RemoteProtocolError) by
@@ -569,7 +569,7 @@ def _fetch_bulk_players(season: str, min_mpg: float) -> list:
     for i in range(0, len(player_ids), _BATCH):
         batch = player_ids[i : i + _BATCH]
         rows = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id, player_id, profile")
             .in_("player_id", batch)
             .eq("season", season)
@@ -596,7 +596,7 @@ def _fetch_bulk_players(season: str, min_mpg: float) -> list:
         for i in range(0, len(profile_ids), _BATCH):
             batch = profile_ids[i : i + _BATCH]
             flags_rows = (
-                supabase.table("skill_flags")
+                supabase.table("draft_skill_flags")
                 .select("skill_profile_id, resolution")
                 .in_("skill_profile_id", batch)
                 .limit(_FLAG_BATCH_LIMIT)
@@ -771,8 +771,8 @@ def search_players():
 def delete_player(player_id: str):
     """
     Permanently delete a player and ALL of their associated data:
-      1. skill_flags  — rows linked via skill_profiles
-      2. skill_profiles — composite and stat profiles for this player
+      1. draft_skill_flags  — rows linked via draft_skill_profiles
+      2. draft_skill_profiles — composite and stat profiles for this player
       3. player_stats — cached stat blobs for this player
       4. players      — the player record itself
 
@@ -789,21 +789,21 @@ def delete_player(player_id: str):
         supabase = get_supabase()
 
         # Step 1: Find all skill_profile IDs for this player so we can delete
-        # their associated flags (FK: skill_flags.skill_profile_id → skill_profiles.id)
+        # their associated flags (FK: draft_skill_flags.skill_profile_id → draft_skill_profiles.id)
         profiles_res = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id")
             .eq("player_id", player_id)
             .execute()
         )
         profile_ids = [row["id"] for row in (profiles_res.data or [])]
 
-        # Step 2: Delete skill_flags linked to those profiles
+        # Step 2: Delete draft_skill_flags linked to those profiles
         if profile_ids:
-            supabase.table("skill_flags").delete().in_("skill_profile_id", profile_ids).execute()
+            supabase.table("draft_skill_flags").delete().in_("skill_profile_id", profile_ids).execute()
 
-        # Step 3: Delete skill_profiles for this player
-        supabase.table("skill_profiles").delete().eq("player_id", player_id).execute()
+        # Step 3: Delete draft_skill_profiles for this player
+        supabase.table("draft_skill_profiles").delete().eq("player_id", player_id).execute()
 
         # Step 4: Delete cached player_stats rows
         supabase.table("player_stats").delete().eq("player_id", player_id).execute()
@@ -943,7 +943,7 @@ def player_profile(player_id: str):
 
         # Fetch composite skill profile (if it exists)
         profile_row = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id, profile")
             .eq("player_id", player_id)
             .eq("season", season)
@@ -965,7 +965,7 @@ def player_profile(player_id: str):
 
             # Fetch flag summary counts
             flag_rows = (
-                supabase.table("skill_flags")
+                supabase.table("draft_skill_flags")
                 .select("id, resolution")
                 .eq("skill_profile_id", composite_profile_id)
                 .execute()

--- a/backend/api/review.py
+++ b/backend/api/review.py
@@ -88,7 +88,7 @@ def review_queue():
 
         # Step 1: Get composite profiles for this season
         composite_profiles = run_query(lambda: (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id, player_id")
             .eq("season", season)
             .eq("source", "composite")
@@ -110,7 +110,7 @@ def review_queue():
             chunk = composite_ids[i : i + _CHUNK]
             # Default arg captures chunk value so the lambda closure is correct
             rows = run_query(lambda c=chunk: (
-                supabase.table("skill_flags")
+                supabase.table("draft_skill_flags")
                 .select("id, skill_profile_id, skill_name, flag_reason")
                 .in_("skill_profile_id", c)
                 .is_("resolution", "null")
@@ -245,7 +245,7 @@ def player_flags(player_id: str):
 
         # Fetch all three skill profiles for this player+season
         profile_rows = run_query(lambda: (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id, source, profile")
             .eq("player_id", player_id)
             .eq("season", season)
@@ -262,7 +262,7 @@ def player_flags(player_id: str):
         flags: list[dict] = []
         if composite_profile_id:
             flag_rows = run_query(lambda: (
-                supabase.table("skill_flags")
+                supabase.table("draft_skill_flags")
                 .select(
                     "id, skill_name, stat_rating, claude_rating, flag_reason, "
                     "stat_values, claude_justification, resolution, resolved_value, "
@@ -320,11 +320,11 @@ def resolve_flag(player_id: str):
     Resolve a single skill flag for a player.
 
     After resolution:
-    - Updates skill_flags: sets resolution, resolved_value, resolved_at, notes.
+    - Updates draft_skill_flags: sets resolution, resolved_value, resolved_at, notes.
     - Updates the composite skill_profile.profile JSONB: final_tier → resolved tier,
       source → "resolved".
     - If ALL flags for this composite profile are now resolved, marks
-      skill_profiles.reviewed = true.
+      draft_skill_profiles.reviewed = true.
 
     Path params:
       player_id — Supabase UUID
@@ -367,7 +367,7 @@ def resolve_flag(player_id: str):
 
         # Find the composite skill_profile for this player+season
         profile_row = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id, profile")
             .eq("player_id", player_id)
             .eq("season", season)
@@ -387,7 +387,7 @@ def resolve_flag(player_id: str):
         # resolved row alongside a new proficient_tier_review flag) don't cause the
         # already-resolved row to be targeted, leaving the real unresolved flag stuck.
         flag_row = (
-            supabase.table("skill_flags")
+            supabase.table("draft_skill_flags")
             .select("id, stat_rating, claude_rating, resolution")
             .eq("skill_profile_id", profile_id)
             .eq("skill_name", skill_name)
@@ -413,7 +413,7 @@ def resolve_flag(player_id: str):
         resolved_at = datetime.now(timezone.utc).isoformat()
 
         # Update the skill_flag record
-        supabase.table("skill_flags").update({
+        supabase.table("draft_skill_flags").update({
             "resolution":     resolution,
             "resolved_value": resolved_tier,
             "resolved_at":    resolved_at,
@@ -428,13 +428,13 @@ def resolve_flag(player_id: str):
                 "source":     "resolved",
             }
             updated_profile = {**profile_data, skill_name: updated_skill}
-            supabase.table("skill_profiles").update({
+            supabase.table("draft_skill_profiles").update({
                 "profile": updated_profile,
             }).eq("id", profile_id).execute()
 
         # Check if all flags for this composite profile are now resolved
         remaining = (
-            supabase.table("skill_flags")
+            supabase.table("draft_skill_flags")
             .select("id")
             .eq("skill_profile_id", profile_id)
             .is_("resolution", "null")
@@ -444,7 +444,7 @@ def resolve_flag(player_id: str):
 
         if all_resolved:
             # Mark the composite profile as fully reviewed
-            supabase.table("skill_profiles").update({
+            supabase.table("draft_skill_profiles").update({
                 "reviewed":    True,
                 "reviewed_at": resolved_at,
             }).eq("id", profile_id).execute()
@@ -511,7 +511,7 @@ def bulk_resolve():
 
         # Find the composite profile
         profile_row = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id, profile")
             .eq("player_id", player_id)
             .eq("season", season)
@@ -528,7 +528,7 @@ def bulk_resolve():
 
         # Get all unresolved flags for this composite profile
         flag_rows = (
-            supabase.table("skill_flags")
+            supabase.table("draft_skill_flags")
             .select("id, skill_name, stat_rating, claude_rating")
             .eq("skill_profile_id", profile_id)
             .is_("resolution", "null")
@@ -556,7 +556,7 @@ def bulk_resolve():
             )
 
             # Update the individual flag record
-            supabase.table("skill_flags").update({
+            supabase.table("draft_skill_flags").update({
                 "resolution":     resolution,
                 "resolved_value": resolved_tier,
                 "resolved_at":    resolved_at,
@@ -574,13 +574,13 @@ def bulk_resolve():
             resolved_count += 1
 
         # Persist the updated composite profile (all skills updated in one write)
-        supabase.table("skill_profiles").update({
+        supabase.table("draft_skill_profiles").update({
             "profile": updated_profile,
         }).eq("id", profile_id).execute()
 
         # Verify that no flags remain unresolved (guards against concurrent modifications)
         remaining = (
-            supabase.table("skill_flags")
+            supabase.table("draft_skill_flags")
             .select("id")
             .eq("skill_profile_id", profile_id)
             .is_("resolution", "null")
@@ -589,7 +589,7 @@ def bulk_resolve():
         all_resolved = len(remaining.data or []) == 0
 
         if all_resolved:
-            supabase.table("skill_profiles").update({
+            supabase.table("draft_skill_profiles").update({
                 "reviewed":    True,
                 "reviewed_at": resolved_at,
             }).eq("id", profile_id).execute()
@@ -654,7 +654,7 @@ def manual_override_skill(player_id: str):
 
         # Find the composite profile for this player+season
         profile_row = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("id, profile")
             .eq("player_id", player_id)
             .eq("season", season)
@@ -676,7 +676,7 @@ def manual_override_skill(player_id: str):
             _empty_skill = {"final_tier": "None", "stat_tier": None, "claude_tier": None, "source": "manual_override", "flagged": False}
             profile_data = {skill: dict(_empty_skill) for skill in _ALL_SKILLS}
             new_profile_row = (
-                supabase.table("skill_profiles")
+                supabase.table("draft_skill_profiles")
                 .insert({
                     "player_id": player_id,
                     "season":    season,
@@ -694,7 +694,7 @@ def manual_override_skill(player_id: str):
 
         # Check if a skill_flag already exists for this skill
         existing_flag = (
-            supabase.table("skill_flags")
+            supabase.table("draft_skill_flags")
             .select("id")
             .eq("skill_profile_id", profile_id)
             .eq("skill_name", skill_name)
@@ -705,7 +705,7 @@ def manual_override_skill(player_id: str):
         if existing_flag.data:
             # Update the existing flag with the manual override resolution
             flag_id = existing_flag.data[0]["id"]
-            supabase.table("skill_flags").update({
+            supabase.table("draft_skill_flags").update({
                 "resolution":     "manual_override",
                 "resolved_value": resolved_value,
                 "resolved_at":    resolved_at,
@@ -715,7 +715,7 @@ def manual_override_skill(player_id: str):
             # Create a new flag row for the manual override
             # Pull the current stat/claude ratings from stored profiles for audit trail
             stats_profile_row = (
-                supabase.table("skill_profiles")
+                supabase.table("draft_skill_profiles")
                 .select("profile")
                 .eq("player_id", player_id)
                 .eq("season", season)
@@ -726,7 +726,7 @@ def manual_override_skill(player_id: str):
             stats_profile = (stats_profile_row.data or [{}])[0].get("profile") or {}
 
             claude_profile_row = (
-                supabase.table("skill_profiles")
+                supabase.table("draft_skill_profiles")
                 .select("profile")
                 .eq("player_id", player_id)
                 .eq("season", season)
@@ -749,7 +749,7 @@ def manual_override_skill(player_id: str):
             else:
                 claude_rating = "None"
 
-            supabase.table("skill_flags").insert({
+            supabase.table("draft_skill_flags").insert({
                 "skill_profile_id":  profile_id,
                 "skill_name":        skill_name,
                 "stat_rating":       stat_rating,
@@ -780,7 +780,7 @@ def manual_override_skill(player_id: str):
                 "flag_reason":  "manual_override",
             }
         updated_profile = {**profile_data, skill_name: updated_skill}
-        supabase.table("skill_profiles").update({
+        supabase.table("draft_skill_profiles").update({
             "profile": updated_profile,
         }).eq("id", profile_id).execute()
 
@@ -869,9 +869,9 @@ def skill_breakdown(player_id: str):
         # Run the condition breakdown — same logic as calibration's test-thresholds
         condition_results = collect_condition_results(rule, stats_blob, league_avgs)
 
-        # Also fetch the stored stat tier from skill_profiles for display
+        # Also fetch the stored stat tier from draft_skill_profiles for display
         profile_row = (
-            supabase.table("skill_profiles")
+            supabase.table("draft_skill_profiles")
             .select("profile")
             .eq("player_id", player_id)
             .eq("season", season)

--- a/backend/api/saved_teams.py
+++ b/backend/api/saved_teams.py
@@ -237,7 +237,7 @@ def _resolve_snapshot_player(
     if not source_player_id:
         return None, None
     res = (
-        supabase.table("snapshot_players")
+        supabase.table("released_players")
         .select("id, canonical_player_id")
         .eq("snapshot_release_id", snapshot_release_id)
         .eq("source_player_id", source_player_id)
@@ -470,7 +470,7 @@ def _resolve_cornerstone_for_rebuild(
     source_id = cornerstone_row.get("source_player_id")
     if source_id:
         res = (
-            supabase.table("snapshot_players")
+            supabase.table("released_players")
             .select("source_player_id, name")
             .eq("snapshot_release_id", current_snapshot_release_id)
             .eq("source_player_id", source_id)
@@ -506,7 +506,7 @@ def _resolve_players_for_rebuild(
 ) -> list[dict[str, Any]]:
     """Resolve each non-cornerstone saved player against the current Snapshot Release.
 
-    Uses canonical_player_id → snapshot_players join. Falls back to
+    Uses canonical_player_id → released_players join. Falls back to
     source_player_id when canonical_player_id is absent (legacy data).
     """
     reports: list[dict[str, Any]] = []
@@ -553,7 +553,7 @@ def _resolve_players_for_rebuild(
         current_row = None
         if canonical_id:
             res = (
-                supabase.table("snapshot_players")
+                supabase.table("released_players")
                 .select("source_player_id, name, team, position, salary, skill_profile_snapshot")
                 .eq("snapshot_release_id", current_snapshot_release_id)
                 .eq("canonical_player_id", canonical_id)
@@ -565,7 +565,7 @@ def _resolve_players_for_rebuild(
                 current_row = rows[0]
         elif source_id:
             res = (
-                supabase.table("snapshot_players")
+                supabase.table("released_players")
                 .select("source_player_id, name, team, position, salary, skill_profile_snapshot")
                 .eq("snapshot_release_id", current_snapshot_release_id)
                 .eq("source_player_id", source_id)

--- a/backend/api/skills.py
+++ b/backend/api/skills.py
@@ -10,7 +10,7 @@ All responses use the standard envelope: {success, data, error}.
 player_id params are Supabase UUIDs.
 
 The skill engine is fully data-driven: all tier logic lives in the
-skill_thresholds table, not in this file. See skill_engine.py.
+draft_skill_thresholds table, not in this file. See skill_engine.py.
 """
 
 import logging
@@ -134,7 +134,7 @@ def player_skills(player_id: str):
 @require_admin
 def batch_skills():
     """
-    Batch-evaluate skills for multiple players and persist results to skill_profiles.
+    Batch-evaluate skills for multiple players and persist results to draft_skill_profiles.
 
     Processes players sequentially (not in parallel) — a full league run
     (all qualifying players) may take several minutes.

--- a/backend/api/snapshots.py
+++ b/backend/api/snapshots.py
@@ -302,7 +302,7 @@ def reactivate_release(release_id: str):
 @snapshots_bp.route("/reset-working-state", methods=["POST"])
 @require_admin
 def reset_working_state():
-    """Reset live skill_profiles and players from the active Snapshot."""
+    """Reset live draft_skill_profiles and players from the active Snapshot."""
     try:
         repo.reset_working_state_from_active()
         return _ok({"ok": True})

--- a/backend/scripts/tune_composite.py
+++ b/backend/scripts/tune_composite.py
@@ -67,14 +67,14 @@ def load_all_profiles() -> list[dict]:
     client = get_supabase()
 
     profiles = run_query(
-        lambda: client.table("skill_profiles")
+        lambda: client.table("draft_skill_profiles")
         .select("player_id, profile")
         .eq("season", SEASON)
         .eq("source", "composite")
         .execute()
     )
     legend_profiles = run_query(
-        lambda: client.table("skill_profiles")
+        lambda: client.table("draft_skill_profiles")
         .select("player_id, profile")
         .eq("source", "manual")
         .eq("is_legend", True)

--- a/backend/services/cohesion_engine/composites.py
+++ b/backend/services/cohesion_engine/composites.py
@@ -363,7 +363,7 @@ def build_distributions(season: str, values: dict[str, Any]) -> dict[str, list[f
     all_raw: dict[str, list[float]] = {name: [] for name in COMPOSITE_NAMES}
 
     profiles = _run_query(
-        lambda: client.table("skill_profiles")
+        lambda: client.table("draft_skill_profiles")
         .select("profile")
         .eq("season", season)
         .eq("source", "composite")
@@ -376,7 +376,7 @@ def build_distributions(season: str, values: dict[str, Any]) -> dict[str, list[f
             all_raw[name].append(value)
 
     legend_profiles = _run_query(
-        lambda: client.table("skill_profiles")
+        lambda: client.table("draft_skill_profiles")
         .select("profile")
         .eq("source", "manual")
         .eq("is_legend", True)

--- a/backend/services/compositing.py
+++ b/backend/services/compositing.py
@@ -29,8 +29,8 @@ Compositing matrix (stat_confidence is the primary axis):
     one-tier disagreements become flagged instead of auto-accepted.
 
 Persistence:
-  Three skill_profiles records per player (source = "stats", "claude", "composite").
-  One skill_flags record per flagged skill.
+  Three draft_skill_profiles records per player (source = "stats", "claude", "composite").
+  One draft_skill_flags record per flagged skill.
 """
 
 import logging
@@ -335,7 +335,7 @@ def _upsert_skill_profile(
     supabase: Client,
 ) -> str:
     """
-    Upsert a skill_profiles record and return its ID.
+    Upsert a draft_skill_profiles record and return its ID.
 
     Unique constraint: (player_id, season, source).
     """
@@ -350,16 +350,16 @@ def _upsert_skill_profile(
         "is_legend":       False,
     }
     result = (
-        supabase.table("skill_profiles")
+        supabase.table("draft_skill_profiles")
         .upsert(row, on_conflict="player_id,season,source")
         .execute()
     )
     record_id = result.data[0]["id"] if result.data else None
-    logger.debug("Upserted skill_profiles source=%s for player %s — id=%s", source, player_id, record_id)
+    logger.debug("Upserted draft_skill_profiles source=%s for player %s — id=%s", source, player_id, record_id)
     return record_id
 
 
-def _upsert_skill_flags(
+def _upsert_draft_skill_flags(
     composite_profile_id: str,
     composite: dict,
     stat_skills_result: dict,
@@ -367,7 +367,7 @@ def _upsert_skill_flags(
     supabase: Client,
 ) -> int:
     """
-    Upsert skill_flags records for every flagged skill.
+    Upsert draft_skill_flags records for every flagged skill.
 
     Uses (skill_profile_id, skill_name) as the logical unique key.
     Supabase does not have a composite unique constraint for upsert here, so
@@ -377,7 +377,7 @@ def _upsert_skill_flags(
         Number of flag records created.
     """
     if not composite_profile_id:
-        logger.warning("Cannot upsert skill_flags — composite_profile_id is None")
+        logger.warning("Cannot upsert draft_skill_flags — composite_profile_id is None")
         return 0
 
     # Collect all flagged skills
@@ -409,14 +409,14 @@ def _upsert_skill_flags(
 
     # Delete existing flags for this composite profile, then re-insert
     # This is the safest upsert strategy for a table without a multi-col unique constraint.
-    supabase.table("skill_flags").delete().eq(
+    supabase.table("draft_skill_flags").delete().eq(
         "skill_profile_id", composite_profile_id
     ).execute()
 
-    supabase.table("skill_flags").insert(flagged_rows).execute()
+    supabase.table("draft_skill_flags").insert(flagged_rows).execute()
 
     logger.debug(
-        "Inserted %d skill_flags for composite profile %s", len(flagged_rows), composite_profile_id
+        "Inserted %d draft_skill_flags for composite profile %s", len(flagged_rows), composite_profile_id
     )
     return len(flagged_rows)
 
@@ -430,7 +430,7 @@ def persist_profiles(
     supabase: Client,
 ) -> dict:
     """
-    Persist all three skill_profiles (stats, claude, composite) and all skill_flags.
+    Persist all three draft_skill_profiles (stats, claude, composite) and all draft_skill_flags.
 
     Args:
         player_id:          Supabase UUID.
@@ -469,7 +469,7 @@ def persist_profiles(
     )
 
     # Skill flags — only for composite profile
-    flags_created = _upsert_skill_flags(
+    flags_created = _upsert_draft_skill_flags(
         composite_profile_id,
         composite,
         stat_skills_result,

--- a/backend/services/skill_engine/cache.py
+++ b/backend/services/skill_engine/cache.py
@@ -2,7 +2,7 @@
 skill_engine/cache.py — Module-level TTL caches for thresholds and league averages.
 
 Provides:
-  - get_thresholds:                     5-min TTL cache, reads skill_thresholds table
+  - get_thresholds:                     5-min TTL cache, reads draft_skill_thresholds table
   - get_league_averages:                24-hr TTL cache, reads league_averages table
   - compute_and_store_league_averages:  compute from player_stats, persist, refresh cache
 """
@@ -79,7 +79,7 @@ def get_thresholds(supabase: Client, refresh: bool = False) -> dict[str, Any]:
 
     logger.info("Loading skill thresholds from Supabase")
     rows = (
-        supabase.table("skill_thresholds")
+        supabase.table("draft_skill_thresholds")
         .select("skill_name, thresholds")
         .execute()
     )

--- a/backend/services/skill_engine/pipeline.py
+++ b/backend/services/skill_engine/pipeline.py
@@ -82,7 +82,7 @@ def batch_evaluate_skills(
     supabase: Client,
 ) -> dict[str, dict]:
     """
-    Evaluate skills for a list of players sequentially and persist to skill_profiles.
+    Evaluate skills for a list of players sequentially and persist to draft_skill_profiles.
 
     If player_ids is empty, fetches all qualifying players (>= DEFAULT_MIN_MPG)
     for the season and processes them all (full league run — may take minutes).
@@ -90,9 +90,9 @@ def batch_evaluate_skills(
     For each player:
       1. Evaluate skills via evaluate_all_skills
       2. Apply auto-promotions
-      3. Upsert the full skills_result into skill_profiles table
+      3. Upsert the full skills_result into draft_skill_profiles table
 
-    The skill_profiles upsert uses (player_id, season, source) as the unique key.
+    The draft_skill_profiles upsert uses (player_id, season, source) as the unique key.
     source is always "stats" for this automated pipeline.
 
     Returns: { player_id: skills_result_dict, ... }
@@ -146,7 +146,7 @@ def batch_evaluate_skills(
             skills_result = evaluate_all_skills(stats_blob, thresholds, league_avgs)
             skills_result = apply_auto_promotions(skills_result, thresholds)
 
-            # Persist to skill_profiles — upsert on (player_id, season, source).
+            # Persist to draft_skill_profiles — upsert on (player_id, season, source).
             # Low-confidence skills are preserved from the existing profile so that
             # hand-tuned or manually reviewed values aren't blown away on every run.
             _upsert_skill_profile(player_id, season, skills_result, supabase, thresholds)
@@ -175,7 +175,7 @@ def _upsert_skill_profile(
     thresholds: dict | None = None,
 ) -> None:
     """
-    Upsert a skill profile record into the skill_profiles table.
+    Upsert a skill profile record into the draft_skill_profiles table.
 
     Unique constraint: (player_id, season, source). If a row already exists
     for this combination, it is updated in-place (profile and timestamps).
@@ -195,7 +195,7 @@ def _upsert_skill_profile(
 
         if low_confidence_skills:
             existing_row = (
-                supabase.table("skill_profiles")
+                supabase.table("draft_skill_profiles")
                 .select("profile")
                 .eq("player_id", player_id)
                 .eq("season", season)
@@ -235,7 +235,7 @@ def _upsert_skill_profile(
     }
 
     # Use upsert with on_conflict specifying the unique column combination
-    supabase.table("skill_profiles").upsert(
+    supabase.table("draft_skill_profiles").upsert(
         profile_row, on_conflict="player_id,season,source"
     ).execute()
 

--- a/backend/services/snapshot_versions/repo.py
+++ b/backend/services/snapshot_versions/repo.py
@@ -203,7 +203,7 @@ def publish_draft(
 
     Steps:
     1. Guard: raise if any pipeline_run is still running for this draft (mirrors move_to_review).
-    2. Call publish_snapshot_draft RPC (freezes snapshot_players, flips is_active).
+    2. Call publish_snapshot_draft RPC (freezes released_players, flips is_active).
     3. _force_clear_distributions() to bypass the draft-pin guard.
     4. ensure_distributions(force=True) to rewarm from the new active snapshot.
     """

--- a/backend/services/snapshot_versions/summary.py
+++ b/backend/services/snapshot_versions/summary.py
@@ -30,7 +30,7 @@ def count_summary(draft_id: str, client=None) -> dict:
             "players_changed_since_active": int,
             "players_missing_composite": int,
             "thresholds_changed": int,           # always 0 in this slice; #7 owns threshold versioning
-            "manual_overrides_since_active": int, # manual skill_profiles updated after active published_at
+            "manual_overrides_since_active": int, # manual draft_skill_profiles updated after active published_at
         }
     """
     c = client or _get_client()
@@ -53,7 +53,7 @@ def count_summary(draft_id: str, client=None) -> dict:
         for i in range(0, len(player_ids), _CHUNK):
             chunk = player_ids[i: i + _CHUNK]
             profiles = run_query(
-                lambda c_chunk=chunk: c.table("skill_profiles")
+                lambda c_chunk=chunk: c.table("draft_skill_profiles")
                 .select("player_id")
                 .in_("player_id", c_chunk)
                 .eq("source", "composite")
@@ -78,7 +78,7 @@ def count_summary(draft_id: str, client=None) -> dict:
             if active_published_at:
                 # Players whose composite profile was updated after the last publish
                 updated_profiles = run_query(
-                    lambda: c.table("skill_profiles")
+                    lambda: c.table("draft_skill_profiles")
                     .select("player_id")
                     .eq("source", "composite")
                     .eq("season", _CURRENT_SEASON)
@@ -90,9 +90,9 @@ def count_summary(draft_id: str, client=None) -> dict:
                 }
                 changed_since_active = len(changed_player_ids)
 
-                # Manual skill_profiles updated after the last publish
+                # Manual draft_skill_profiles updated after the last publish
                 manual_profiles = run_query(
-                    lambda: c.table("skill_profiles")
+                    lambda: c.table("draft_skill_profiles")
                     .select("player_id")
                     .eq("source", "manual")
                     .eq("season", _CURRENT_SEASON)

--- a/backend/services/snapshot_versions/validator.py
+++ b/backend/services/snapshot_versions/validator.py
@@ -72,7 +72,7 @@ def validate_publishable(
         for i in range(0, len(player_ids), _CHUNK):
             chunk = player_ids[i: i + _CHUNK]
             profiles = run_query(
-                lambda c_chunk=chunk: c.table("skill_profiles")
+                lambda c_chunk=chunk: c.table("draft_skill_profiles")
                 .select("player_id")
                 .in_("player_id", c_chunk)
                 .eq("source", "composite")

--- a/backend/tests/test_saved_teams_api.py
+++ b/backend/tests/test_saved_teams_api.py
@@ -523,7 +523,7 @@ def test_save_team_resolves_snapshot_player_ids_on_insert(client, fake_supabase)
     """Server resolves snapshot_player_id + canonical_player_id from source_player_id."""
     for slot in range(2, 10):
         source_player_id = f"44444444-4444-4444-4444-44444444444{slot}"
-        fake_supabase.rows.setdefault("snapshot_players", []).append({
+        fake_supabase.rows.setdefault("released_players", []).append({
             "id": SNAPSHOT_PLAYER_IDS[slot],
             "snapshot_release_id": SNAPSHOT_RELEASE_ID,
             "canonical_player_id": CANONICAL_PLAYER_IDS[slot],
@@ -682,7 +682,7 @@ def _seed_saved_team(fake_supabase, *, missing_slots: list[int] | None = None):
     for slot in range(2, 10):
         if slot in missing:
             continue
-        fake_supabase.rows.setdefault("snapshot_players", []).append({
+        fake_supabase.rows.setdefault("released_players", []).append({
             "id": f"current-snap-{slot}",
             "snapshot_release_id": CURRENT_SNAPSHOT_RELEASE_ID,
             "canonical_player_id": CANONICAL_PLAYER_IDS[slot],
@@ -1294,7 +1294,7 @@ def _seed_shared_team_for_rebuild(fake_supabase, *, visibility: str = "public") 
 
     for slot in range(2, 10):
         source_player_id = f"44444444-4444-4444-4444-44444444444{slot}"
-        fake_supabase.rows.setdefault("snapshot_players", []).append({
+        fake_supabase.rows.setdefault("released_players", []).append({
             "id": f"current-snap-{slot}",
             "snapshot_release_id": CURRENT_SNAPSHOT_RELEASE_ID,
             "canonical_player_id": CANONICAL_PLAYER_IDS.get(slot),

--- a/backend/tests/test_snapshot_versions_repo.py
+++ b/backend/tests/test_snapshot_versions_repo.py
@@ -227,10 +227,10 @@ class TestDiscardDraft:
         with patch.object(repo, "_get_client", return_value=client):
             repo.discard_draft(draft_id)  # should not raise
 
-        # Verify DELETE was called on snapshot_releases, NOT on skill_profiles
+        # Verify DELETE was called on snapshot_releases, NOT on draft_skill_profiles
         assert client.table.call_args_list[0][0][0] == "snapshot_releases"
         all_tables_accessed = [call[0][0] for call in client.table.call_args_list]
-        assert "skill_profiles" not in all_tables_accessed
+        assert "draft_skill_profiles" not in all_tables_accessed
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_snapshot_versions_summary.py
+++ b/backend/tests/test_snapshot_versions_summary.py
@@ -54,8 +54,8 @@ class TestCountSummaryFields:
             _result(players),           # players query
             _result(composite_profiles),# composite profiles chunk
             _result(active_row),        # active snapshot_releases
-            _result(changed_profiles),  # skill_profiles updated after published_at
-            _result(manual_profiles),   # manual skill_profiles updated after published_at
+            _result(changed_profiles),  # draft_skill_profiles updated after published_at
+            _result(manual_profiles),   # manual draft_skill_profiles updated after published_at
         ]
 
         exec_mock = MagicMock(side_effect=execute_seq)
@@ -93,7 +93,7 @@ class TestCountSummaryFields:
 
     def test_count_summary_returns_manual_overrides_since_active(self):
         """manual_overrides_since_active must be present and count manual
-        skill_profiles updated after the active snapshot's published_at."""
+        draft_skill_profiles updated after the active snapshot's published_at."""
         from services.snapshot_versions import summary
 
         manual_profile = _make_skill_profile("p1", source="manual")

--- a/backend/tests/test_snapshot_versions_validator.py
+++ b/backend/tests/test_snapshot_versions_validator.py
@@ -62,7 +62,7 @@ class TestValidatePublishableMissingCompositePlayers:
                 mock_rq.side_effect = [
                     _result(players),  # players query
                     _result([{"nba_api_id": "1"}, {"nba_api_id": "1"}]),  # canonical_players
-                    _result([]),  # composite skill_profiles — both missing
+                    _result([]),  # composite draft_skill_profiles — both missing
                 ]
                 result = validator.validate_publishable("draft-001")
 
@@ -89,7 +89,7 @@ class TestValidatePublishableMissingCompositePlayers:
                     _result(
                         [{"nba_api_id": str(i)} for i in range(75)]
                     ),  # canonical_players — all match
-                    _result([]),  # composite skill_profiles — all missing
+                    _result([]),  # composite draft_skill_profiles — all missing
                 ]
                 result = validator.validate_publishable("draft-001")
 
@@ -108,7 +108,7 @@ class TestValidatePublishableMissingCompositePlayers:
                     _result([{"nba_api_id": "1"}]),  # canonical_players
                     _result(
                         [{"player_id": "p1"}, {"player_id": "p2"}]
-                    ),  # composite skill_profiles — none missing
+                    ),  # composite draft_skill_profiles — none missing
                 ]
                 result = validator.validate_publishable("draft-001")
 

--- a/frontend/app/admin/snapshots/_components/DiscardActions.tsx
+++ b/frontend/app/admin/snapshots/_components/DiscardActions.tsx
@@ -120,7 +120,7 @@ export function DiscardActions({ id, draftId, onDiscarded }: DiscardActionsProps
           >
             Reset working state from active Snapshot
             <span className="block text-[11px] text-neutral-400 mt-0.5">
-              Overwrites live skill_profiles and player salaries.
+              Overwrites live draft_skill_profiles and player salaries.
             </span>
           </button>
         </div>
@@ -133,7 +133,7 @@ export function DiscardActions({ id, draftId, onDiscarded }: DiscardActionsProps
         </h2>
         <p id={`${id}-discard-body`} className="text-xs text-neutral-600 mb-5">
           The draft row will be permanently deleted. Live tables are untouched — any
-          pipeline output from this draft remains in <code className="font-mono">skill_profiles</code>.
+          pipeline output from this draft remains in <code className="font-mono">draft_skill_profiles</code>.
           A new draft can be created immediately.
         </p>
         <div id={`${id}-discard-actions`} className="flex justify-end gap-3">
@@ -166,7 +166,7 @@ export function DiscardActions({ id, draftId, onDiscarded }: DiscardActionsProps
         <p id={`${id}-reset-body`} className="text-xs text-neutral-600 mb-3">
           This will <strong>overwrite</strong> all live{" "}
           <code className="font-mono">composite</code> and{" "}
-          <code className="font-mono">stats</code> skill_profiles for the current season,
+          <code className="font-mono">stats</code> draft_skill_profiles for the current season,
           and reset player salary/team/position to the values frozen in the active published Snapshot.
           Any pipeline output from this draft will be lost.
         </p>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -480,7 +480,7 @@ export async function bulkResolveFlags(
 // ---------------------------------------------------------------------------
 
 /**
- * Permanently delete a player and all associated data (skill_profiles, skill_flags, player_stats).
+ * Permanently delete a player and all associated data (draft_skill_profiles, draft_skill_flags, player_stats).
  * This is irreversible.
  */
 export async function deletePlayer(

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -137,7 +137,7 @@ export interface ThresholdRule {
   [key: string]: unknown;
 }
 
-/** Row from skill_thresholds table */
+/** Row from draft_skill_thresholds table */
 export interface ThresholdRow {
   id: string;
   skill_name: string;
@@ -235,7 +235,7 @@ export interface FlaggedPlayerSummary {
   flag_reasons: string[];
 }
 
-/** A single skill flag record from the skill_flags table */
+/** A single skill flag record from the draft_skill_flags table */
 export interface SkillFlag {
   id: string;
   skill_name: string;
@@ -250,7 +250,7 @@ export interface SkillFlag {
   notes: string | null;
 }
 
-/** Composite skill result stored in the skill_profiles.profile JSONB */
+/** Composite skill result stored in the draft_skill_profiles.profile JSONB */
 export interface CompositeSkillResult {
   final_tier: string;
   stat_tier: string | null;
@@ -930,6 +930,6 @@ export interface SnapshotCountSummary {
   players_missing_composite: number;
   /** Always 0 in this slice — issue #7 owns threshold versioning. */
   thresholds_changed: number;
-  /** manual skill_profiles updated after the active snapshot's published_at. */
+  /** manual draft_skill_profiles updated after the active snapshot's published_at. */
   manual_overrides_since_active: number;
 }

--- a/supabase/migrations/20260527000000_rename_working_tables.sql
+++ b/supabase/migrations/20260527000000_rename_working_tables.sql
@@ -1,0 +1,254 @@
+-- =============================================================================
+-- Rename working tables for draft/released clarity (prep for issue #7).
+--
+-- Under Model Y, the "live" calibration tables ARE the active draft's working
+-- area, and the snapshot_players table is the frozen released read source.
+-- The current names misled the design process. This migration renames:
+--
+--   skill_profiles    -> draft_skill_profiles
+--   skill_flags       -> draft_skill_flags
+--   skill_thresholds  -> draft_skill_thresholds
+--   snapshot_players  -> released_players
+--
+-- Indexes and triggers are renamed for clarity. Functions that text-reference
+-- the old table names are recreated against the new names (Postgres function
+-- bodies are stored as text and do not auto-resolve to the new table).
+--
+-- Guarded with DO blocks so a partially-applied state will not error.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Table renames
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables
+             WHERE table_schema = 'public' AND table_name = 'skill_profiles') THEN
+    ALTER TABLE public.skill_profiles RENAME TO draft_skill_profiles;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM information_schema.tables
+             WHERE table_schema = 'public' AND table_name = 'skill_flags') THEN
+    ALTER TABLE public.skill_flags RENAME TO draft_skill_flags;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM information_schema.tables
+             WHERE table_schema = 'public' AND table_name = 'skill_thresholds') THEN
+    ALTER TABLE public.skill_thresholds RENAME TO draft_skill_thresholds;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM information_schema.tables
+             WHERE table_schema = 'public' AND table_name = 'snapshot_players') THEN
+    ALTER TABLE public.snapshot_players RENAME TO released_players;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Index renames (clarity; not required for correctness)
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_skill_profiles_player_id') THEN
+    ALTER INDEX public.idx_skill_profiles_player_id RENAME TO idx_draft_skill_profiles_player_id;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_skill_profiles_is_legend') THEN
+    ALTER INDEX public.idx_skill_profiles_is_legend RENAME TO idx_draft_skill_profiles_is_legend;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_skill_profiles_review') THEN
+    ALTER INDEX public.idx_skill_profiles_review RENAME TO idx_draft_skill_profiles_review;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_skill_profiles_legend_id') THEN
+    ALTER INDEX public.idx_skill_profiles_legend_id RENAME TO idx_draft_skill_profiles_legend_id;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_skill_flags_profile_id') THEN
+    ALTER INDEX public.idx_skill_flags_profile_id RENAME TO idx_draft_skill_flags_profile_id;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_skill_flags_unresolved') THEN
+    ALTER INDEX public.idx_skill_flags_unresolved RENAME TO idx_draft_skill_flags_unresolved;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_snapshot_players_release_name') THEN
+    ALTER INDEX public.idx_snapshot_players_release_name RENAME TO idx_released_players_release_name;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_snapshot_players_canonical') THEN
+    ALTER INDEX public.idx_snapshot_players_canonical RENAME TO idx_released_players_canonical;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Constraint renames (uq_/chk_)
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'uq_snapshot_players_source_player') THEN
+    ALTER TABLE public.released_players RENAME CONSTRAINT uq_snapshot_players_source_player TO uq_released_players_source_player;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_snapshot_players_salary') THEN
+    ALTER TABLE public.released_players RENAME CONSTRAINT chk_snapshot_players_salary TO chk_released_players_salary;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Trigger renames
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_skill_profiles_updated_at' AND NOT tgisinternal) THEN
+    ALTER TRIGGER trg_skill_profiles_updated_at ON public.draft_skill_profiles RENAME TO trg_draft_skill_profiles_updated_at;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_skill_thresholds_updated_at' AND NOT tgisinternal) THEN
+    ALTER TRIGGER trg_skill_thresholds_updated_at ON public.draft_skill_thresholds RENAME TO trg_draft_skill_thresholds_updated_at;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- RLS policy renames (policy bodies don't reference table names by string,
+-- but the policy name on snapshot_players reads as "snapshot players").
+-- Recreate with new name for clarity.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'released_players'
+      AND policyname = 'Anyone can read snapshot players'
+  ) THEN
+    ALTER POLICY "Anyone can read snapshot players" ON public.released_players RENAME TO "Anyone can read released players";
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Recreate functions that text-reference the old table names.
+-- Bodies copied from 20260526000002_snapshot_publish_rpc_fix.sql with table
+-- references swapped to the new names. No behavior change.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.publish_snapshot_draft(
+  p_draft_id UUID,
+  p_label TEXT,
+  p_allow_missing_composite BOOLEAN DEFAULT false
+)
+RETURNS public.snapshot_releases
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_release public.snapshot_releases;
+  v_missing_composite INTEGER;
+BEGIN
+  SELECT * INTO v_release
+    FROM public.snapshot_releases
+    WHERE id = p_draft_id AND status IN ('draft', 'review')
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'draft_not_found_or_not_in_draft_state';
+  END IF;
+
+  SELECT COUNT(*) INTO v_missing_composite
+  FROM public.players p
+  LEFT JOIN public.draft_skill_profiles sp
+    ON sp.player_id = p.id AND sp.source = 'composite'
+  WHERE p.season = '2025-26' AND sp.id IS NULL;
+
+  IF v_missing_composite > 0 AND NOT p_allow_missing_composite THEN
+    RAISE EXCEPTION 'missing_composite_not_acknowledged: % players', v_missing_composite;
+  END IF;
+
+  WITH composite_profiles AS (
+    SELECT DISTINCT ON (player_id) id, player_id, profile
+    FROM public.draft_skill_profiles
+    WHERE source = 'composite' AND is_legend = false
+    ORDER BY player_id, updated_at DESC NULLS LAST, created_at DESC NULLS LAST
+  )
+  INSERT INTO public.released_players (
+    snapshot_release_id,
+    canonical_player_id,
+    source_player_id,
+    source_skill_profile_id,
+    stat_season,
+    name,
+    team,
+    position,
+    salary,
+    skill_profile_snapshot
+  )
+  SELECT
+    p_draft_id,
+    cp.id,
+    p.id,
+    sp.id,
+    p.season,
+    p.name,
+    p.team,
+    p.position,
+    COALESCE(p.salary, 0),
+    COALESCE(sp.profile, '{}'::jsonb)
+  FROM public.players p
+  JOIN public.canonical_players cp ON cp.nba_api_id = p.nba_api_id
+  LEFT JOIN composite_profiles sp ON sp.player_id = p.id
+  WHERE p.season = '2025-26';
+
+  UPDATE public.snapshot_releases
+    SET is_active = false
+    WHERE is_active = true;
+
+  UPDATE public.snapshot_releases
+    SET
+      status = 'published',
+      is_active = true,
+      label = p_label,
+      published_at = now(),
+      data_cutoff_at = now()
+    WHERE id = p_draft_id
+    RETURNING * INTO v_release;
+
+  RETURN v_release;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reset_working_state_from_active()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_active_id UUID;
+BEGIN
+  SELECT id INTO v_active_id
+    FROM public.snapshot_releases
+    WHERE is_active = true
+    LIMIT 1;
+
+  IF v_active_id IS NULL THEN
+    RAISE EXCEPTION 'no_active_snapshot_release';
+  END IF;
+
+  DELETE FROM public.draft_skill_profiles
+    WHERE source = 'composite'
+      AND season = '2025-26'
+      AND is_legend = false;
+
+  INSERT INTO public.draft_skill_profiles (player_id, season, source, profile, is_legend, created_at)
+  SELECT
+    sp.source_player_id,
+    sp.stat_season,
+    'composite',
+    sp.skill_profile_snapshot,
+    false,
+    now()
+  FROM public.released_players sp
+  WHERE sp.snapshot_release_id = v_active_id
+    AND sp.source_player_id IS NOT NULL;
+
+  UPDATE public.players p
+  SET
+    salary   = sp.salary,
+    team     = sp.team,
+    position = sp.position
+  FROM public.released_players sp
+  WHERE sp.snapshot_release_id = v_active_id
+    AND sp.source_player_id = p.id;
+END;
+$$;


### PR DESCRIPTION
## Summary

Mechanical rename prep for issue #7 (draft-aware skill mapping and threshold editing). **No behavior change.**

Renames:
- `skill_profiles` → `draft_skill_profiles`
- `skill_flags` → `draft_skill_flags`
- `skill_thresholds` → `draft_skill_thresholds`
- `snapshot_players` → `released_players`

Under Model Y semantics chosen for #7, the live calibration tables ARE the active draft's working state, and `released_players` is the production read Surface. The previous names misled the design process; new names make the working/released Boundary explicit in code.

## Why a separate prep PR?

Touching 50+ files mechanically would obscure the behavior-change diff in the #7 PR. Reviewer for this PR verifies *purely renames, no behavior change*; reviewer for #7 sees only the new logic.

## What's in the migration

`supabase/migrations/20260527000000_rename_working_tables.sql`:
- `ALTER TABLE … RENAME TO …` (guarded with `IF EXISTS` for idempotence)
- Index, trigger, constraint, RLS policy renames for clarity
- `CREATE OR REPLACE` of `publish_snapshot_draft` and `reset_working_state_from_active` — Postgres function bodies are stored as text and don't auto-resolve to renamed tables. Function logic is byte-equivalent to `20260526000002_snapshot_publish_rpc_fix.sql` with only table name swaps.

Historical migration files are left untouched (immutable record of schema evolution).

## What's in the code diff

- 25 files touched via targeted `sed`: backend services/API/tests + frontend `lib/api.ts`, `lib/types.ts`, `DiscardActions.tsx`
- Comments and JSDoc referencing the renamed tables updated to match
- No column renames; only table-name string references and the four target identifiers

## Test plan

- [x] Backend test suite: 508 pass (2 pre-existing failures in `test_composites.py` — unrelated, present on `main`)
- [x] Frontend lint: clean except 1 pre-existing warning in `PipelineCard.tsx` — unrelated, present on `main`
- [x] `supabase db push` applies the rename migration cleanly against the linked project
- [x] Local smoke test: `/lab/standard/build` loads; `/admin/snapshots` shows the active release; `/admin/calibration` reads thresholds

## Follow-ups (issue #7)

This PR sets up the rename. The #7 PR builds on it:
- `pipeline_run_results` staging tables
- `skill_evaluation` and `threshold_edit` pipeline kinds
- Lab read pin to `released_players`
- Tabbed draft workspace at `/admin/snapshots/draft`

See `feature_requests/draft-aware-skill-mapping-plan.md` for the full ExecPlan.