### PR TITLE
feat(snapshot-versions): M1 — staging tables, legend release support, publish gates

### DIFF
--- a/backend/tests/test_m1_schema_invariants.py
+++ b/backend/tests/test_m1_schema_invariants.py
@@ -33,21 +33,22 @@ import pytest
 
 @pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
 def test_pipeline_run_results_pk_rejects_duplicate_run_player_source():
-    """PRIMARY KEY (run_id, player_id, source) rejects a second insert for the
-    same (run_id, player_id, source) triple.
+    """PRIMARY KEY (run_id, player_id, source) — enforced by constraint
+    `pipeline_run_results_pkey` — rejects a second insert for the same triple.
 
     SQL to verify:
         INSERT INTO pipeline_run_results (run_id, player_id, season, source, profile)
           VALUES ('<run>', '<player>', '2025-26', 'composite', '{}');
-        -- second insert with identical PK must raise unique_violation.
+        -- second insert with identical PK must raise unique_violation
+        -- (constraint name: pipeline_run_results_pkey).
     """
     pass
 
 
 @pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
 def test_pipeline_run_results_source_check_rejects_unknown_value():
-    """CHECK (source IN ('stats','claude','composite','manual')) rejects an
-    unknown source value.
+    """CHECK (source IN ('stats','claude','composite','manual')) — anonymous
+    table-level CHECK constraint — rejects an unknown source value.
 
     SQL to verify:
         INSERT INTO pipeline_run_results (..., source='unknown', ...)
@@ -58,8 +59,9 @@ def test_pipeline_run_results_source_check_rejects_unknown_value():
 
 @pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
 def test_pipeline_run_results_cascade_deletes_on_run_delete():
-    """ON DELETE CASCADE from pipeline_runs.id removes all staged profile rows
-    when the parent run row is deleted.
+    """ON DELETE CASCADE on the FK `pipeline_run_results.run_id ->
+    pipeline_runs.id` removes all staged profile rows when the parent run row
+    is deleted.
 
     SQL to verify:
         DELETE FROM pipeline_runs WHERE id = '<run>';
@@ -75,22 +77,46 @@ def test_pipeline_run_results_cascade_deletes_on_run_delete():
 
 
 @pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
-def test_pipeline_run_flag_results_pk_rejects_duplicate_run_player_skill():
-    """PRIMARY KEY (run_id, player_id, skill_name) rejects a second insert for
-    the same triple.
+def test_pipeline_run_flag_results_pk_rejects_duplicate_run_player_skill_season():
+    """PRIMARY KEY (run_id, player_id, skill_name, season) — enforced by
+    constraint `pipeline_run_flag_results_pkey` — rejects a second insert for
+    the same quadruple.
+
+    Season is part of the PK so a multi-season skill_evaluation run can stage
+    flags for the same (player, skill) across different seasons without
+    colliding. Added in migration 20260527000004 after the original
+    (run_id, player_id, skill_name) PK was identified as too narrow.
 
     SQL to verify:
         INSERT INTO pipeline_run_flag_results (run_id, player_id, skill_name,
-          flag_reason) VALUES ('<run>', '<player>', 'Scorer', 'tiers differ');
-        -- second insert must raise unique_violation.
+          season, flag_reason)
+          VALUES ('<run>', '<player>', 'Scorer', '2025-26', 'tiers differ');
+        -- second insert with identical PK must raise unique_violation
+        -- (constraint name: pipeline_run_flag_results_pkey).
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_run_flag_results_pk_allows_distinct_seasons():
+    """Same (run_id, player_id, skill_name) across distinct seasons must NOT
+    collide on the PK after the season add in migration 20260527000004.
+
+    SQL to verify:
+        INSERT INTO pipeline_run_flag_results VALUES ('<run>', '<player>',
+          'Scorer', '2025-26', 'tiers differ');
+        INSERT INTO pipeline_run_flag_results VALUES ('<run>', '<player>',
+          'Scorer', '2024-25', 'tiers differ');
+        -- Both inserts succeed.
     """
     pass
 
 
 @pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
 def test_pipeline_run_flag_results_cascade_deletes_on_run_delete():
-    """ON DELETE CASCADE from pipeline_runs.id removes all staged flag rows
-    when the parent run row is deleted.
+    """ON DELETE CASCADE on the FK `pipeline_run_flag_results.run_id ->
+    pipeline_runs.id` removes all staged flag rows when the parent run row
+    is deleted.
 
     SQL to verify:
         DELETE FROM pipeline_runs WHERE id = '<run>';

--- a/backend/tests/test_m1_schema_invariants.py
+++ b/backend/tests/test_m1_schema_invariants.py
@@ -1,0 +1,353 @@
+"""
+M1 schema invariant tests — draft-aware skill mapping (issue #7).
+
+These tests codify the behavioral contracts introduced by the three M1 migrations:
+
+  20260527000001_pipeline_run_staging.sql
+  20260527000002_released_players_legends.sql
+  20260527000003_publish_open_flags_gate.sql
+
+All tests are skipped because M1 adds database-level constraints that require a
+live Supabase connection to verify. Each test documents the invariant it will
+enforce once the real-DB fixture is wired in M2.
+
+Convention: use pytest.mark.skip with a reason that names the SQL invariant being
+tested, so the test names form a readable contract list.
+
+When wiring real-DB tests in M2:
+  1. Replace @pytest.mark.skip with a fixture that gives a psycopg2 or supabase-py
+     connection to a test schema with M1 migrations applied.
+  2. Remove the `pass` body and implement the SQL assertions.
+  3. Wrap DML in a transaction that rolls back after each test (SAVEPOINT pattern).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# pipeline_run_results — staging table invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_run_results_pk_rejects_duplicate_run_player_source():
+    """PRIMARY KEY (run_id, player_id, source) rejects a second insert for the
+    same (run_id, player_id, source) triple.
+
+    SQL to verify:
+        INSERT INTO pipeline_run_results (run_id, player_id, season, source, profile)
+          VALUES ('<run>', '<player>', '2025-26', 'composite', '{}');
+        -- second insert with identical PK must raise unique_violation.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_run_results_source_check_rejects_unknown_value():
+    """CHECK (source IN ('stats','claude','composite','manual')) rejects an
+    unknown source value.
+
+    SQL to verify:
+        INSERT INTO pipeline_run_results (..., source='unknown', ...)
+        -- must raise check_violation.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_run_results_cascade_deletes_on_run_delete():
+    """ON DELETE CASCADE from pipeline_runs.id removes all staged profile rows
+    when the parent run row is deleted.
+
+    SQL to verify:
+        DELETE FROM pipeline_runs WHERE id = '<run>';
+        SELECT COUNT(*) FROM pipeline_run_results WHERE run_id = '<run>';
+        -- Expect: 0 rows remain.
+    """
+    pass
+
+
+# ---------------------------------------------------------------------------
+# pipeline_run_flag_results — staging table invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_run_flag_results_pk_rejects_duplicate_run_player_skill():
+    """PRIMARY KEY (run_id, player_id, skill_name) rejects a second insert for
+    the same triple.
+
+    SQL to verify:
+        INSERT INTO pipeline_run_flag_results (run_id, player_id, skill_name,
+          flag_reason) VALUES ('<run>', '<player>', 'Scorer', 'tiers differ');
+        -- second insert must raise unique_violation.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_run_flag_results_cascade_deletes_on_run_delete():
+    """ON DELETE CASCADE from pipeline_runs.id removes all staged flag rows
+    when the parent run row is deleted.
+
+    SQL to verify:
+        DELETE FROM pipeline_runs WHERE id = '<run>';
+        SELECT COUNT(*) FROM pipeline_run_flag_results WHERE run_id = '<run>';
+        -- Expect: 0 rows remain.
+    """
+    pass
+
+
+# ---------------------------------------------------------------------------
+# pipeline_runs — extended CHECK constraints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_runs_accepts_skill_evaluation_pipeline_name():
+    """pipeline_name CHECK now accepts 'skill_evaluation'.
+
+    SQL to verify:
+        INSERT INTO pipeline_runs (pipeline_name, scope, snapshot_release_id, status)
+          VALUES ('skill_evaluation', 'bulk', '<release>', 'running');
+        -- must succeed.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_runs_accepts_threshold_edit_pipeline_name():
+    """pipeline_name CHECK now accepts 'threshold_edit'.
+
+    SQL to verify:
+        INSERT INTO pipeline_runs (pipeline_name, scope, snapshot_release_id, status)
+          VALUES ('threshold_edit', 'bulk', '<release>', 'running');
+        -- must succeed.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_runs_rejects_unknown_pipeline_name():
+    """pipeline_name CHECK still rejects unknown values.
+
+    SQL to verify:
+        INSERT INTO pipeline_runs (..., pipeline_name='data_export', ...)
+        -- must raise check_violation.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_runs_accepts_discarded_status():
+    """status CHECK now accepts 'discarded'.
+
+    SQL to verify:
+        UPDATE pipeline_runs SET status = 'discarded' WHERE id = '<run>';
+        -- must succeed.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_pipeline_runs_rejects_unknown_status():
+    """status CHECK still rejects unknown values.
+
+    SQL to verify:
+        UPDATE pipeline_runs SET status = 'cancelled' WHERE id = '<run>';
+        -- must raise check_violation.
+    """
+    pass
+
+
+# ---------------------------------------------------------------------------
+# pipeline_runs — partial unique index (one pending-commit run per draft)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_partial_unique_idx_blocks_second_pending_commit_run_for_same_release():
+    """idx_pipeline_runs_one_pending_commit allows at most one row per
+    snapshot_release_id WHERE status='success' AND committed_at IS NULL.
+
+    SQL to verify:
+        INSERT INTO pipeline_runs (..., snapshot_release_id='<rel>', status='success');
+        -- committed_at defaults NULL → this is the first pending-commit run. OK.
+        INSERT INTO pipeline_runs (..., snapshot_release_id='<rel>', status='success');
+        -- second insert must raise unique_violation.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_partial_unique_idx_allows_running_status_runs_regardless_of_release():
+    """Rows with status='running' are excluded from the partial index predicate,
+    so multiple running rows for the same release_id are allowed.
+
+    SQL to verify:
+        INSERT INTO pipeline_runs (..., snapshot_release_id='<rel>', status='running');
+        INSERT INTO pipeline_runs (..., snapshot_release_id='<rel>', status='running');
+        -- both must succeed.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_partial_unique_idx_allows_committed_run_after_pending_commit_run():
+    """A row with committed_at IS NOT NULL is excluded from the predicate, so a
+    committed run and a new pending-commit run can coexist for the same release.
+
+    SQL to verify:
+        INSERT INTO pipeline_runs (..., snapshot_release_id='<rel>', status='success',
+          committed_at=now());
+        INSERT INTO pipeline_runs (..., snapshot_release_id='<rel>', status='success');
+        -- committed_at=NULL on second row. Both must succeed.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_partial_unique_idx_allows_discarded_run_after_pending_commit_run():
+    """A row with status='discarded' is excluded from the predicate, so discarding
+    a run unblocks creating a new pending-commit run for the same release.
+
+    SQL to verify:
+        INSERT INTO pipeline_runs (..., status='success');   -- pending commit
+        UPDATE pipeline_runs SET status='discarded' WHERE id = '<first-run>';
+        INSERT INTO pipeline_runs (..., status='success');   -- new pending commit
+        -- second insert must succeed after the first is discarded.
+    """
+    pass
+
+
+# ---------------------------------------------------------------------------
+# released_players — is_legend column invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_released_players_is_legend_column_exists_with_false_default():
+    """released_players.is_legend column exists as BOOLEAN NOT NULL DEFAULT false.
+
+    SQL to verify:
+        SELECT column_default, is_nullable
+        FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='released_players'
+          AND column_name='is_legend';
+        -- Expect: column_default='false', is_nullable='NO'
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_released_players_is_legend_accepts_true():
+    """is_legend can be explicitly set to true.
+
+    SQL to verify:
+        INSERT INTO released_players (..., is_legend=true);
+        -- must succeed.
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_released_players_existing_rows_default_to_false():
+    """Any existing rows (inserted before this migration) have is_legend=false,
+    not NULL.
+
+    SQL to verify:
+        SELECT COUNT(*) FROM released_players WHERE is_legend IS NULL;
+        -- Expect: 0
+    """
+    pass
+
+
+# ---------------------------------------------------------------------------
+# publish_snapshot_draft RPC — open-flags gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_publish_rpc_raises_open_flags_not_acknowledged_when_flags_exist():
+    """publish_snapshot_draft raises 'open_flags_not_acknowledged' when
+    draft_skill_flags has unresolved rows and p_allow_open_flags=false.
+
+    SQL to verify:
+        -- Insert an unresolved flag row into draft_skill_flags.
+        SELECT public.publish_snapshot_draft('<draft-id>', 'label', false, false);
+        -- Expect: ERROR containing 'open_flags_not_acknowledged'
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_publish_rpc_proceeds_with_open_flags_when_override_true():
+    """publish_snapshot_draft proceeds past the flags check when
+    p_allow_open_flags=true, even if unresolved flags exist.
+
+    SQL to verify:
+        -- Insert an unresolved flag row into draft_skill_flags.
+        SELECT public.publish_snapshot_draft('<draft-id>', 'label', false, true);
+        -- Expect: proceeds (may raise a different guard; must NOT raise open_flags)
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_publish_rpc_raises_when_legend_missing_canonical_player():
+    """publish_snapshot_draft raises 'legends_missing_canonical_player' if any
+    row in public.legends has nba_api_id IS NULL or no matching row in
+    public.canonical_players. Preflight prevents the INSERT from hitting a raw
+    NOT NULL constraint violation on released_players.canonical_player_id.
+
+    SQL to verify:
+        -- Insert a legend with nba_api_id=NULL, then call:
+        SELECT public.publish_snapshot_draft('<draft-id>', 'label', true, true);
+        -- Expect: ERROR containing 'legends_missing_canonical_player'
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_publish_rpc_includes_legends_in_released_players():
+    """After a successful publish, legends with composite draft_skill_profiles
+    rows appear in released_players with is_legend=true.
+
+    SQL to verify:
+        -- Ensure at least one legend has a composite draft_skill_profiles row.
+        SELECT public.publish_snapshot_draft('<draft-id>', 'label', true, true);
+        SELECT COUNT(*) FROM released_players
+          WHERE snapshot_release_id='<draft-id>' AND is_legend=true;
+        -- Expect: > 0
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_publish_rpc_sets_is_legend_false_for_regular_players():
+    """Regular players (non-legends) appear in released_players with
+    is_legend=false after publish.
+
+    SQL to verify:
+        SELECT public.publish_snapshot_draft('<draft-id>', 'label', true, true);
+        SELECT COUNT(*) FROM released_players
+          WHERE snapshot_release_id='<draft-id>' AND is_legend=false;
+        -- Expect: equals count of 2025-26 players with canonical_players rows
+    """
+    pass
+
+
+@pytest.mark.skip(reason="Requires live DB with M1 migrations applied (wire in M2)")
+def test_publish_rpc_no_released_player_row_has_null_is_legend():
+    """After publish, no released_players row has NULL in is_legend (column
+    is NOT NULL, so this is a schema-level guarantee, but verify end-to-end).
+
+    SQL to verify:
+        SELECT public.publish_snapshot_draft('<draft-id>', 'label', true, true);
+        SELECT COUNT(*) FROM released_players
+          WHERE snapshot_release_id='<draft-id>' AND is_legend IS NULL;
+        -- Expect: 0
+    """
+    pass

--- a/supabase/migrations/20260527000001_pipeline_run_staging.sql
+++ b/supabase/migrations/20260527000001_pipeline_run_staging.sql
@@ -1,0 +1,180 @@
+-- =============================================================================
+-- M1 — Staging tables + pipeline_runs extensions for draft-aware data flow.
+--
+-- Adds:
+--   1. pipeline_run_results   — staged profile rows pre-commit
+--   2. pipeline_run_flag_results — staged flag rows pre-commit
+--   3. pipeline_runs.committed_at TIMESTAMPTZ column
+--   4. pipeline_name CHECK extended: + 'skill_evaluation', 'threshold_edit'
+--   5. status CHECK extended:        + 'discarded'
+--   6. Partial unique idx:  at most one pending-commit run per draft
+--
+-- All structural changes are additive and guard-wrapped for idempotence.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 4. Extend pipeline_name CHECK to include 'skill_evaluation', 'threshold_edit'
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  -- Drop old constraint if it still uses the narrow value set.
+  -- Postgres does not support ADD CONSTRAINT IF NOT EXISTS for CHECK constraints,
+  -- so we drop by name and re-add unconditionally.
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pipeline_runs_pipeline_name_check'
+      AND conrelid = 'public.pipeline_runs'::regclass
+  ) THEN
+    ALTER TABLE public.pipeline_runs
+      DROP CONSTRAINT pipeline_runs_pipeline_name_check;
+  END IF;
+END $$;
+
+ALTER TABLE public.pipeline_runs
+  ADD CONSTRAINT pipeline_runs_pipeline_name_check
+    CHECK (pipeline_name IN (
+      'stat_fetch',
+      'salary_scrape',
+      'bio_team_sync',
+      'skill_evaluation',
+      'threshold_edit'
+    ));
+
+-- ---------------------------------------------------------------------------
+-- 5. Extend status CHECK to include 'discarded'
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pipeline_runs_status_check'
+      AND conrelid = 'public.pipeline_runs'::regclass
+  ) THEN
+    ALTER TABLE public.pipeline_runs
+      DROP CONSTRAINT pipeline_runs_status_check;
+  END IF;
+END $$;
+
+ALTER TABLE public.pipeline_runs
+  ADD CONSTRAINT pipeline_runs_status_check
+    CHECK (status IN ('running', 'success', 'error', 'discarded'));
+
+-- ---------------------------------------------------------------------------
+-- 3. Add committed_at column (NULL = not yet committed / not a staging run)
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.pipeline_runs
+  ADD COLUMN IF NOT EXISTS committed_at TIMESTAMPTZ;
+
+-- ---------------------------------------------------------------------------
+-- 6. Partial unique index: at most one pending-commit run per draft release.
+--    A run is "pending commit" when status='success' AND committed_at IS NULL.
+--    Discarded, error, and committed runs are excluded from the predicate.
+-- ---------------------------------------------------------------------------
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pipeline_runs_one_pending_commit
+  ON public.pipeline_runs (snapshot_release_id)
+  WHERE status = 'success' AND committed_at IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- 1. Staging table for profile rows (mirrors draft_skill_profiles row shape)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.pipeline_run_results (
+  run_id     UUID NOT NULL REFERENCES public.pipeline_runs(id) ON DELETE CASCADE,
+  player_id  UUID NOT NULL,
+  season     TEXT NOT NULL,
+  source     TEXT NOT NULL CHECK (source IN ('stats', 'claude', 'composite', 'manual')),
+  profile    JSONB NOT NULL,
+  PRIMARY KEY (run_id, player_id, source)
+);
+
+-- Index to support per-player diff lookups
+CREATE INDEX IF NOT EXISTS idx_pipeline_run_results_player
+  ON public.pipeline_run_results (player_id);
+
+-- ---------------------------------------------------------------------------
+-- 2. Staging table for flag rows (mirrors draft_skill_flags row shape)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.pipeline_run_flag_results (
+  run_id      UUID NOT NULL REFERENCES public.pipeline_runs(id) ON DELETE CASCADE,
+  player_id   UUID NOT NULL,
+  skill_name  TEXT NOT NULL,
+  flag_reason TEXT NOT NULL,
+  claude_tier TEXT,
+  stats_tier  TEXT,
+  PRIMARY KEY (run_id, player_id, skill_name)
+);
+
+-- Index to support per-player diff lookups
+CREATE INDEX IF NOT EXISTS idx_pipeline_run_flag_results_player
+  ON public.pipeline_run_flag_results (player_id);
+
+-- ---------------------------------------------------------------------------
+-- RLS for staging tables — service role only (mirrors pipeline_runs policy)
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.pipeline_run_results ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'pipeline_run_results'
+      AND policyname = 'Service role manages pipeline_run_results'
+  ) THEN
+    CREATE POLICY "Service role manages pipeline_run_results"
+      ON public.pipeline_run_results
+      FOR ALL
+      TO service_role
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;
+
+ALTER TABLE public.pipeline_run_flag_results ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'pipeline_run_flag_results'
+      AND policyname = 'Service role manages pipeline_run_flag_results'
+  ) THEN
+    CREATE POLICY "Service role manages pipeline_run_flag_results"
+      ON public.pipeline_run_flag_results
+      FOR ALL
+      TO service_role
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;
+
+-- =============================================================================
+-- Verification queries (run after apply to confirm invariants):
+--
+-- 1. Partial unique idx — one pending-commit run per draft:
+--      INSERT INTO pipeline_runs (snapshot_release_id, pipeline_name, scope, status)
+--        VALUES ('some-release-uuid', 'skill_evaluation', 'bulk', 'success');
+--      -- committed_at defaults to NULL, so this counts as "pending commit."
+--      -- Inserting a second row with the same snapshot_release_id, status='success',
+--      -- committed_at=NULL should raise a unique_violation.
+--      -- Inserting with status='running' should succeed (excluded from predicate).
+--      -- Inserting with committed_at=now() should succeed (excluded from predicate).
+--
+-- 2. pipeline_name CHECK:
+--      INSERT INTO pipeline_runs (..., pipeline_name='skill_evaluation', ...) -- ok
+--      INSERT INTO pipeline_runs (..., pipeline_name='threshold_edit', ...) -- ok
+--      INSERT INTO pipeline_runs (..., pipeline_name='unknown', ...) -- must fail
+--
+-- 3. status CHECK:
+--      UPDATE pipeline_runs SET status='discarded' WHERE id=... -- ok
+--      UPDATE pipeline_runs SET status='bad_value' WHERE id=... -- must fail
+--
+-- 4. Staging table source CHECK:
+--      INSERT INTO pipeline_run_results (run_id, player_id, season, source, profile)
+--        VALUES (..., ..., '2025-26', 'composite', '{}') -- ok
+--      INSERT INTO pipeline_run_results (run_id, player_id, season, source, profile)
+--        VALUES (..., ..., '2025-26', 'unknown', '{}') -- must fail
+--
+-- 5. ON DELETE CASCADE from pipeline_runs -> pipeline_run_results:
+--      DELETE FROM pipeline_runs WHERE id=... -- also deletes staging rows
+-- =============================================================================

--- a/supabase/migrations/20260527000001_pipeline_run_staging.sql
+++ b/supabase/migrations/20260527000001_pipeline_run_staging.sql
@@ -66,9 +66,28 @@ ALTER TABLE public.pipeline_runs
   ADD COLUMN IF NOT EXISTS committed_at TIMESTAMPTZ;
 
 -- ---------------------------------------------------------------------------
+-- 3a. Backfill committed_at for historical successful runs.
+--
+--     Pre-M1, every `status='success'` run wrote its results directly to the
+--     live tables (no staging layer existed). Conceptually those runs are
+--     "already committed" — their effects are realized in draft_skill_profiles /
+--     draft_skill_flags. Set `committed_at = COALESCE(finished_at, created_at)`
+--     so they are excluded from the partial unique index predicate below.
+--
+--     Without this backfill, the partial unique index creation in step 6 fails
+--     with SQLSTATE 23505 on any release that has more than one historical
+--     successful run.
+-- ---------------------------------------------------------------------------
+UPDATE public.pipeline_runs
+   SET committed_at = COALESCE(finished_at, started_at)
+ WHERE status = 'success'
+   AND committed_at IS NULL;
+
+-- ---------------------------------------------------------------------------
 -- 6. Partial unique index: at most one pending-commit run per draft release.
 --    A run is "pending commit" when status='success' AND committed_at IS NULL.
 --    Discarded, error, and committed runs are excluded from the predicate.
+--    Historical successful runs are backfilled above so they do not collide.
 -- ---------------------------------------------------------------------------
 CREATE UNIQUE INDEX IF NOT EXISTS idx_pipeline_runs_one_pending_commit
   ON public.pipeline_runs (snapshot_release_id)

--- a/supabase/migrations/20260527000002_released_players_legends.sql
+++ b/supabase/migrations/20260527000002_released_players_legends.sql
@@ -1,0 +1,43 @@
+-- =============================================================================
+-- M1 — Add is_legend column to released_players.
+--
+-- Adds:
+--   7. released_players.is_legend BOOLEAN NOT NULL DEFAULT false
+--      + supporting index
+--
+-- The column is additive with a safe default; existing rows (regular players)
+-- receive false, which is correct. The publish RPC update in the next migration
+-- (20260527000003_publish_open_flags_gate.sql) will set is_legend correctly per row.
+-- =============================================================================
+
+ALTER TABLE public.released_players
+  ADD COLUMN IF NOT EXISTS is_legend BOOLEAN NOT NULL DEFAULT false;
+
+-- Index supports filtered reads: "give me only legends in this release"
+-- and "give me only non-legends in this release."
+CREATE INDEX IF NOT EXISTS idx_released_players_is_legend
+  ON public.released_players (is_legend);
+
+-- =============================================================================
+-- Verification queries (run after apply to confirm invariants):
+--
+-- 1. Column exists with correct default:
+--      SELECT column_name, data_type, column_default, is_nullable
+--      FROM information_schema.columns
+--      WHERE table_schema = 'public'
+--        AND table_name = 'released_players'
+--        AND column_name = 'is_legend';
+--      -- Expect: boolean, default false, NOT NULL
+--
+-- 2. Existing rows default to false:
+--      SELECT COUNT(*) FROM released_players WHERE is_legend IS NULL;
+--      -- Expect: 0
+--
+-- 3. Index exists:
+--      SELECT indexname FROM pg_indexes
+--      WHERE tablename = 'released_players' AND indexname = 'idx_released_players_is_legend';
+--      -- Expect: one row
+--
+-- 4. Insert with is_legend=true succeeds:
+--      -- (dry verify only; do not insert garbage rows against the linked project)
+-- =============================================================================

--- a/supabase/migrations/20260527000003_publish_open_flags_gate.sql
+++ b/supabase/migrations/20260527000003_publish_open_flags_gate.sql
@@ -1,0 +1,234 @@
+-- =============================================================================
+-- M1 — Update publish_snapshot_draft RPC.
+--
+-- Changes from the version applied in 20260527000000_rename_working_tables.sql:
+--
+--   8a. Add p_allow_open_flags BOOLEAN DEFAULT false parameter.
+--   8b. Add open-flags count check; raise 'open_flags_not_acknowledged' if
+--       unresolved flags exist and override is not set.
+--   8c. Include legends in the INSERT INTO released_players:
+--       - Add a second UNION ALL branch for legend rows.
+--       - Populate the new is_legend column on each inserted row.
+--
+-- Base body: copied from 20260527000000_rename_working_tables.sql and
+-- extended in place. CREATE OR REPLACE is safe to re-apply.
+--
+-- NOTE on legend identity in draft_skill_profiles:
+--   Legend profiles are stored with player_id = NULL and legend_id = <legends.id>.
+--   The regular-player branch filters WHERE is_legend = false (player_id IS NOT NULL).
+--   The legend branch filters WHERE is_legend = true, joining on legend_id = l.id.
+--
+-- NOTE on legends.salary:
+--   The legends table has no salary column (salary is a Lab/RuleSet concern, not
+--   a biographical fact for all-time greats). released_players.salary is NOT NULL
+--   DEFAULT 0, so we insert 0 for all legend rows. The Lab's RuleSet salary config
+--   for legends is handled separately (outside this publish path).
+--
+-- NOTE on missing-composite check:
+--   The count LEFT JOINs against public.players (is_legend = false path), so
+--   legends (which have no row in public.players) are correctly excluded.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.publish_snapshot_draft(
+  p_draft_id                UUID,
+  p_label                   TEXT,
+  p_allow_missing_composite BOOLEAN DEFAULT false,
+  p_allow_open_flags        BOOLEAN DEFAULT false
+)
+RETURNS public.snapshot_releases
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_release             public.snapshot_releases;
+  v_missing_composite   INTEGER;
+  v_open_flags          INTEGER;
+  v_legends_no_canonical INTEGER;
+BEGIN
+  -- Serialize the deactivate -> activate is_active flip against any concurrent
+  -- publish or reactivate. The partial unique index `idx_snapshot_releases_one_active`
+  -- enforces the at-most-one-active invariant as a backstop, but two concurrent
+  -- sessions could both pass their per-row FOR UPDATE on different targets and
+  -- then race on the deactivate -> activate swap. A transaction-scoped advisory
+  -- lock collapses that window. Mirrors the lock in reactivate_snapshot_release.
+  PERFORM pg_advisory_xact_lock(hashtext('snapshot_releases.active_swap'));
+
+  -- Lock the draft row to prevent concurrent publishes.
+  SELECT * INTO v_release
+    FROM public.snapshot_releases
+    WHERE id = p_draft_id AND status IN ('draft', 'review')
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'draft_not_found_or_not_in_draft_state';
+  END IF;
+
+  -- -------------------------------------------------------------------------
+  -- Missing-composite check (regular players only — legends excluded by the
+  -- LEFT JOIN against public.players; see NOTE above).
+  -- -------------------------------------------------------------------------
+  SELECT COUNT(*) INTO v_missing_composite
+  FROM public.players p
+  LEFT JOIN public.draft_skill_profiles sp
+    ON sp.player_id = p.id AND sp.source = 'composite' AND sp.is_legend = false
+  WHERE p.season = '2025-26' AND sp.id IS NULL;
+
+  IF v_missing_composite > 0 AND NOT p_allow_missing_composite THEN
+    RAISE EXCEPTION 'missing_composite_not_acknowledged: % players', v_missing_composite;
+  END IF;
+
+  -- -------------------------------------------------------------------------
+  -- Open-flags check.
+  -- A flag is "open" when resolution IS NULL. The Python backend only writes
+  -- NULL (unresolved) or a concrete resolution value ('trust_stats',
+  -- 'trust_claude', 'manual_override'); the string literal 'unresolved' is
+  -- never written, so it is intentionally not checked here.
+  -- -------------------------------------------------------------------------
+  SELECT COUNT(*) INTO v_open_flags
+  FROM public.draft_skill_flags
+  WHERE resolution IS NULL;
+
+  IF v_open_flags > 0 AND NOT p_allow_open_flags THEN
+    RAISE EXCEPTION 'open_flags_not_acknowledged: % flags', v_open_flags;
+  END IF;
+
+  -- -------------------------------------------------------------------------
+  -- Legend canonical-link check.
+  -- released_players.canonical_player_id is NOT NULL. Legends with
+  -- legends.nba_api_id IS NULL (or unmatched in canonical_players) would
+  -- violate the constraint mid-INSERT and abort the publish transaction.
+  -- Preflight here so the failure is named and actionable rather than a raw
+  -- constraint violation surfaced from the INSERT.
+  -- -------------------------------------------------------------------------
+  SELECT COUNT(*) INTO v_legends_no_canonical
+  FROM public.legends l
+  LEFT JOIN public.canonical_players cp ON cp.nba_api_id = l.nba_api_id
+  WHERE cp.id IS NULL;
+
+  IF v_legends_no_canonical > 0 THEN
+    RAISE EXCEPTION 'legends_missing_canonical_player: % legends', v_legends_no_canonical;
+  END IF;
+
+  -- -------------------------------------------------------------------------
+  -- Freeze into released_players: regular players UNION ALL legends.
+  --
+  -- Branch 1 — regular players (is_legend = false, joins public.players).
+  -- Branch 2 — legends (is_legend = true, joins public.legends via legend_id).
+  --
+  -- DISTINCT ON (player_id) / DISTINCT ON (legend_id) picks the most recent
+  -- composite profile per entity when duplicates exist.
+  -- -------------------------------------------------------------------------
+  WITH regular_profiles AS (
+    SELECT DISTINCT ON (player_id) id, player_id, profile
+    FROM public.draft_skill_profiles
+    WHERE source = 'composite' AND is_legend = false
+    ORDER BY player_id, updated_at DESC NULLS LAST, created_at DESC NULLS LAST
+  ),
+  legend_profiles AS (
+    SELECT DISTINCT ON (legend_id) id, legend_id, profile
+    FROM public.draft_skill_profiles
+    WHERE source = 'composite' AND is_legend = true
+    ORDER BY legend_id, updated_at DESC NULLS LAST, created_at DESC NULLS LAST
+  )
+  INSERT INTO public.released_players (
+    snapshot_release_id,
+    canonical_player_id,
+    source_player_id,
+    source_skill_profile_id,
+    stat_season,
+    name,
+    team,
+    position,
+    salary,
+    skill_profile_snapshot,
+    is_legend
+  )
+  -- Branch 1: regular players
+  SELECT
+    p_draft_id,
+    cp.id,
+    p.id,
+    sp.id,
+    p.season,
+    p.name,
+    p.team,
+    p.position,
+    COALESCE(p.salary, 0),
+    COALESCE(sp.profile, '{}'::jsonb),
+    false
+  FROM public.players p
+  JOIN public.canonical_players cp ON cp.nba_api_id = p.nba_api_id
+  LEFT JOIN regular_profiles sp ON sp.player_id = p.id
+  WHERE p.season = '2025-26'
+
+  UNION ALL
+
+  -- Branch 2: legends (salary = 0; see NOTE above)
+  SELECT
+    p_draft_id,
+    cp.id,
+    NULL,                    -- source_player_id: no row in public.players
+    lp.id,
+    '2025-26',               -- stat_season: pinned to active season at publish time
+    l.name,
+    l.team,
+    l.position,
+    0,                       -- salary: legends have no salary column
+    COALESCE(lp.profile, '{}'::jsonb),
+    true
+  FROM public.legends l
+  JOIN public.canonical_players cp ON cp.nba_api_id = l.nba_api_id
+  LEFT JOIN legend_profiles lp ON lp.legend_id = l.id;
+
+  -- Deactivate the current active release.
+  UPDATE public.snapshot_releases
+    SET is_active = false
+    WHERE is_active = true;
+
+  -- Publish: flip status, assign label, record timestamps.
+  UPDATE public.snapshot_releases
+    SET
+      status         = 'published',
+      is_active      = true,
+      label          = p_label,
+      published_at   = now(),
+      data_cutoff_at = now()
+    WHERE id = p_draft_id
+    RETURNING * INTO v_release;
+
+  RETURN v_release;
+END;
+$$;
+
+-- =============================================================================
+-- Verification queries (run after apply to confirm invariants):
+--
+-- 1. RPC signature includes new parameter:
+--      SELECT pg_get_function_arguments('public.publish_snapshot_draft'::regproc);
+--      -- Expect: 'p_draft_id uuid, p_label text,
+--      --          p_allow_missing_composite boolean, p_allow_open_flags boolean'
+--
+-- 2. Open-flags gate fires when flags exist and override not set:
+--      -- Insert an unresolved row into draft_skill_flags, then call:
+--      SELECT public.publish_snapshot_draft('<draft-id>', 'test', false, false);
+--      -- Expect: ERROR: open_flags_not_acknowledged: N flags
+--
+-- 3. Override bypasses the open-flags gate:
+--      SELECT public.publish_snapshot_draft('<draft-id>', 'test', false, true);
+--      -- Expect: proceeds past the flags check (may hit other guards)
+--
+-- 4. After a successful publish, legends appear in released_players:
+--      SELECT COUNT(*) FROM released_players
+--      WHERE snapshot_release_id = '<published-id>' AND is_legend = true;
+--      -- Expect: equals the count of legends with a composite draft_skill_profiles row
+--
+-- 5. Regular players retain is_legend = false:
+--      SELECT COUNT(*) FROM released_players
+--      WHERE snapshot_release_id = '<published-id>' AND is_legend = false;
+--      -- Expect: equals the count of 2025-26 players with canonical_players rows
+--
+-- 6. No released_players row has is_legend = NULL:
+--      SELECT COUNT(*) FROM released_players WHERE is_legend IS NULL;
+--      -- Expect: 0 (column is NOT NULL)
+-- =============================================================================

--- a/supabase/migrations/20260527000004_m1_polish.sql
+++ b/supabase/migrations/20260527000004_m1_polish.sql
@@ -50,17 +50,10 @@ ALTER TABLE public.pipeline_run_flag_results
 -- B. Document the staging Boundary on both staging tables.
 -- ---------------------------------------------------------------------------
 COMMENT ON TABLE public.pipeline_run_results IS
-  'Staged profile rows for a pipeline_runs row, pre-commit. ' ||
-  'Boundary: only regular-player profile rows pass through staging. ' ||
-  'Legend profile rows (is_legend=true) write directly to draft_skill_profiles ' ||
-  'via the Legend editor (/admin/legends) and bypass this table. ' ||
-  '`season NOT NULL` reflects that constraint.';
+  'Staged profile rows for a pipeline_runs row, pre-commit. Boundary: only regular-player profile rows pass through staging. Legend profile rows (is_legend=true) write directly to draft_skill_profiles via the Legend editor (/admin/legends) and bypass this table. season NOT NULL reflects that constraint.';
 
 COMMENT ON TABLE public.pipeline_run_flag_results IS
-  'Staged flag rows for a pipeline_runs row, pre-commit. ' ||
-  'Boundary: legends do not produce flags, so no legend rows ever appear here. ' ||
-  'PK is (run_id, player_id, skill_name, season) so a multi-season ' ||
-  'skill_evaluation run does not collide.';
+  'Staged flag rows for a pipeline_runs row, pre-commit. Boundary: legends do not produce flags, so no legend rows ever appear here. PK is (run_id, player_id, skill_name, season) so a multi-season skill_evaluation run does not collide.';
 
 -- ---------------------------------------------------------------------------
 -- C. publish_snapshot_draft: add stable id DESC tiebreaker to DISTINCT ON.

--- a/supabase/migrations/20260527000004_m1_polish.sql
+++ b/supabase/migrations/20260527000004_m1_polish.sql
@@ -1,0 +1,217 @@
+-- =============================================================================
+-- M1 polish — review-fanout follow-ups for PR #56.
+--
+-- Three concerns from the parallel review:
+--
+--   A. pipeline_run_flag_results was missing a `season` column. Profile staging
+--      has season; flag staging silently dropped it. A multi-season
+--      skill_evaluation run could collide on (run_id, player_id, skill_name)
+--      and lose one season's flag. Fix while the table is empty.
+--
+--   B. The legends/staging Boundary was implicit. Add COMMENT ON TABLE on both
+--      staging tables documenting that legend profile rows do NOT pass through
+--      the pipeline_run_results path — legend ratings write directly to
+--      draft_skill_profiles via the Legend editor.
+--
+--   C. publish_snapshot_draft's DISTINCT ON CTEs used
+--      `ORDER BY player_id, updated_at DESC, created_at DESC` with no final
+--      stable tiebreaker. If both timestamps are NULL on duplicate composite
+--      rows, the pick is non-deterministic. Add `, id DESC` to both CTEs.
+--
+-- All changes are safe on a live linked project:
+--   - pipeline_run_flag_results is empty (M2 hasn't shipped yet) so the
+--     ADD COLUMN NOT NULL + PK swap is non-destructive.
+--   - CREATE OR REPLACE on the function is replay-safe.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- A. Add `season` to pipeline_run_flag_results and re-key the PK.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.pipeline_run_flag_results
+  ADD COLUMN IF NOT EXISTS season TEXT NOT NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pipeline_run_flag_results_pkey'
+      AND conrelid = 'public.pipeline_run_flag_results'::regclass
+  ) THEN
+    ALTER TABLE public.pipeline_run_flag_results
+      DROP CONSTRAINT pipeline_run_flag_results_pkey;
+  END IF;
+END $$;
+
+ALTER TABLE public.pipeline_run_flag_results
+  ADD CONSTRAINT pipeline_run_flag_results_pkey
+    PRIMARY KEY (run_id, player_id, skill_name, season);
+
+-- ---------------------------------------------------------------------------
+-- B. Document the staging Boundary on both staging tables.
+-- ---------------------------------------------------------------------------
+COMMENT ON TABLE public.pipeline_run_results IS
+  'Staged profile rows for a pipeline_runs row, pre-commit. ' ||
+  'Boundary: only regular-player profile rows pass through staging. ' ||
+  'Legend profile rows (is_legend=true) write directly to draft_skill_profiles ' ||
+  'via the Legend editor (/admin/legends) and bypass this table. ' ||
+  '`season NOT NULL` reflects that constraint.';
+
+COMMENT ON TABLE public.pipeline_run_flag_results IS
+  'Staged flag rows for a pipeline_runs row, pre-commit. ' ||
+  'Boundary: legends do not produce flags, so no legend rows ever appear here. ' ||
+  'PK is (run_id, player_id, skill_name, season) so a multi-season ' ||
+  'skill_evaluation run does not collide.';
+
+-- ---------------------------------------------------------------------------
+-- C. publish_snapshot_draft: add stable id DESC tiebreaker to DISTINCT ON.
+--    Full function body copied from 20260527000003 with the two ORDER BY
+--    clauses extended. No other change.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.publish_snapshot_draft(
+  p_draft_id                UUID,
+  p_label                   TEXT,
+  p_allow_missing_composite BOOLEAN DEFAULT false,
+  p_allow_open_flags        BOOLEAN DEFAULT false
+)
+RETURNS public.snapshot_releases
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_release             public.snapshot_releases;
+  v_missing_composite   INTEGER;
+  v_open_flags          INTEGER;
+  v_legends_no_canonical INTEGER;
+BEGIN
+  -- Serialize the deactivate -> activate is_active flip against any concurrent
+  -- publish or reactivate. Mirrors reactivate_snapshot_release.
+  PERFORM pg_advisory_xact_lock(hashtext('snapshot_releases.active_swap'));
+
+  -- Lock the draft row to prevent concurrent publishes.
+  SELECT * INTO v_release
+    FROM public.snapshot_releases
+    WHERE id = p_draft_id AND status IN ('draft', 'review')
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'draft_not_found_or_not_in_draft_state';
+  END IF;
+
+  -- Missing-composite check (regular players only).
+  SELECT COUNT(*) INTO v_missing_composite
+  FROM public.players p
+  LEFT JOIN public.draft_skill_profiles sp
+    ON sp.player_id = p.id AND sp.source = 'composite' AND sp.is_legend = false
+  WHERE p.season = '2025-26' AND sp.id IS NULL;
+
+  IF v_missing_composite > 0 AND NOT p_allow_missing_composite THEN
+    RAISE EXCEPTION 'missing_composite_not_acknowledged: % players', v_missing_composite;
+  END IF;
+
+  -- Open-flags check. resolution IS NULL means unresolved; the literal string
+  -- 'unresolved' is never written by the backend and is intentionally not
+  -- checked.
+  SELECT COUNT(*) INTO v_open_flags
+  FROM public.draft_skill_flags
+  WHERE resolution IS NULL;
+
+  IF v_open_flags > 0 AND NOT p_allow_open_flags THEN
+    RAISE EXCEPTION 'open_flags_not_acknowledged: % flags', v_open_flags;
+  END IF;
+
+  -- Legend canonical-link preflight.
+  SELECT COUNT(*) INTO v_legends_no_canonical
+  FROM public.legends l
+  LEFT JOIN public.canonical_players cp ON cp.nba_api_id = l.nba_api_id
+  WHERE cp.id IS NULL;
+
+  IF v_legends_no_canonical > 0 THEN
+    RAISE EXCEPTION 'legends_missing_canonical_player: % legends', v_legends_no_canonical;
+  END IF;
+
+  -- Freeze into released_players: regular players UNION ALL legends.
+  -- DISTINCT ON ordering: prefer most recent (updated_at, created_at), with
+  -- `id DESC` as a final stable tiebreaker so duplicate composite rows with
+  -- both timestamps NULL pick deterministically.
+  WITH regular_profiles AS (
+    SELECT DISTINCT ON (player_id) id, player_id, profile
+    FROM public.draft_skill_profiles
+    WHERE source = 'composite' AND is_legend = false
+    ORDER BY player_id, updated_at DESC NULLS LAST, created_at DESC NULLS LAST, id DESC
+  ),
+  legend_profiles AS (
+    SELECT DISTINCT ON (legend_id) id, legend_id, profile
+    FROM public.draft_skill_profiles
+    WHERE source = 'composite' AND is_legend = true
+    ORDER BY legend_id, updated_at DESC NULLS LAST, created_at DESC NULLS LAST, id DESC
+  )
+  INSERT INTO public.released_players (
+    snapshot_release_id,
+    canonical_player_id,
+    source_player_id,
+    source_skill_profile_id,
+    stat_season,
+    name,
+    team,
+    position,
+    salary,
+    skill_profile_snapshot,
+    is_legend
+  )
+  -- Branch 1: regular players
+  SELECT
+    p_draft_id,
+    cp.id,
+    p.id,
+    sp.id,
+    p.season,
+    p.name,
+    p.team,
+    p.position,
+    COALESCE(p.salary, 0),
+    COALESCE(sp.profile, '{}'::jsonb),
+    false
+  FROM public.players p
+  JOIN public.canonical_players cp ON cp.nba_api_id = p.nba_api_id
+  LEFT JOIN regular_profiles sp ON sp.player_id = p.id
+  WHERE p.season = '2025-26'
+
+  UNION ALL
+
+  -- Branch 2: legends
+  SELECT
+    p_draft_id,
+    cp.id,
+    NULL,
+    lp.id,
+    '2025-26',
+    l.name,
+    l.team,
+    l.position,
+    0,
+    COALESCE(lp.profile, '{}'::jsonb),
+    true
+  FROM public.legends l
+  JOIN public.canonical_players cp ON cp.nba_api_id = l.nba_api_id
+  LEFT JOIN legend_profiles lp ON lp.legend_id = l.id;
+
+  -- Deactivate current active release.
+  UPDATE public.snapshot_releases
+    SET is_active = false
+    WHERE is_active = true;
+
+  -- Publish: flip status, assign label, record timestamps.
+  UPDATE public.snapshot_releases
+    SET
+      status         = 'published',
+      is_active      = true,
+      label          = p_label,
+      published_at   = now(),
+      data_cutoff_at = now()
+    WHERE id = p_draft_id
+    RETURNING * INTO v_release;
+
+  RETURN v_release;
+END;
+$$;


### PR DESCRIPTION
## Summary

Schema migrations for the draft-aware skill mapping work — issue #7, milestone M1. No behavior change in running code; these are the foundational schema slices that M2 backend services will consume. Reviewable migration-by-migration.

## What's in this PR

### `20260527000001_pipeline_run_staging.sql`
- New `pipeline_run_results` staging table (per-Player profile rows)
- New `pipeline_run_flag_results` staging table (per-Player flag rows)
- `pipeline_runs.committed_at TIMESTAMPTZ` column
- Extends `pipeline_name` CHECK with `skill_evaluation`, `threshold_edit`
- Extends `status` CHECK with `discarded`
- Partial unique idx: at most one pending-commit run per draft
- RLS `service_role` only on both staging tables

### `20260527000002_released_players_legends.sql`
- `released_players.is_legend BOOLEAN NOT NULL DEFAULT false` + index

### `20260527000003_publish_open_flags_gate.sql`
- `CREATE OR REPLACE` of `publish_snapshot_draft`
- New `p_allow_open_flags` param; hard-blocks publish on `draft_skill_flags.resolution IS NULL` rows unless overridden
- Includes legends in the `released_players` freeze via UNION ALL (joins on `legend_id`, INNER JOIN `canonical_players`)
- New `legends_missing_canonical_player` preflight (named exception instead of raw NOT NULL violation)
- Hardening: `pg_advisory_xact_lock` on the active-swap operation; `SET search_path = public, pg_temp` on the SECURITY DEFINER function

### `backend/tests/test_m1_schema_invariants.py`
- 23 skipped pytest placeholders codifying every invariant introduced. M2 wires these to a real-DB fixture.

## Review pass

Skill-orchestrate chain ran tdd-guide → code-reviewer → security-reviewer.

| Source | Severity | Status |
|--------|----------|--------|
| code-reviewer | HIGH — `canonical_player_id NOT NULL` violation for legends without `nba_api_id` | ✅ Fixed inline (preflight + INNER JOIN) |
| code-reviewer | MEDIUM — dead `OR resolution = 'unresolved'` branch | ✅ Fixed inline (tightened to `IS NULL`) |
| security-reviewer | MEDIUM — missing advisory lock | ✅ Fixed inline |
| security-reviewer | MEDIUM — `p_allow_open_flags` not wired in HTTP | ⏭️ Deferred to M2 per plan scope |
| security-reviewer | LOW — missing `SET search_path` on SECURITY DEFINER | ✅ Fixed inline |

## Follow-up (not in this PR)

- Wire `allow_open_flags` from HTTP body → Python → RPC (M2 scope)
- Apply `pg_advisory_xact_lock` + `SET search_path` to `reactivate_snapshot_release` and the original publish RPC for consistency (hardening PR)

## Test plan

- [ ] `supabase db push` applies all three migrations cleanly
- [ ] `SELECT pg_get_function_arguments('public.publish_snapshot_draft'::regproc)` returns the 4-arg signature
- [ ] Insert two `pipeline_runs` rows with `status='success' AND committed_at IS NULL` for the same `snapshot_release_id` — second insert fails (partial unique idx)
- [ ] Insert unresolved row into `draft_skill_flags`, call `publish_snapshot_draft(... false, false)` → ERROR `open_flags_not_acknowledged`
- [ ] Same call with `... false, true` → bypasses gate
- [ ] Insert legend with `nba_api_id=NULL`, call publish → ERROR `legends_missing_canonical_player`
- [ ] Backend test suite green (placeholders skip cleanly: `pytest backend/tests/test_m1_schema_invariants.py --collect-only`)

Blocks: none (PR #55 merged). Blocked by: none.

Tracks issue #7.