### PR TITLE
feat(snapshot-versions): pin Lab reads to released_players (M3)

### DIFF
--- a/backend/api/legends.py
+++ b/backend/api/legends.py
@@ -29,7 +29,35 @@ from services.skills import (
     ALL_SKILLS as _ALL_SKILLS_FROM_MODULE,
     SKILL_DEFINITIONS as _SKILL_DEFINITIONS_FROM_MODULE,
 )
+from services.snapshots_active import (
+    ActiveReleaseMissingError,
+    get_active_release_id,
+)
+from services.snapshot_versions.released_repo import (
+    fetch_legend_profiles_by_nba_api_ids,
+)
 from services.supabase_client import get_supabase
+
+# ---------------------------------------------------------------------------
+# Source-mode Boundary for legend reads (M3 follow-up)
+# ---------------------------------------------------------------------------
+#
+# Legend GET routes serve BOTH the Lab user-facing picker and the /admin/legends
+# editor. Lab MUST see frozen ratings from the active Snapshot Release;
+# admin MUST see in-progress draft ratings. The default is the safe Lab mode
+# (released); admin pages opt in to draft via ?source=draft.
+
+_SOURCE_RELEASED = "released"
+_SOURCE_DRAFT = "draft"
+_VALID_SOURCES = {_SOURCE_RELEASED, _SOURCE_DRAFT}
+
+
+def _resolve_source() -> str:
+    """Return the requested source mode, defaulting to released (safe Lab default)."""
+    raw = (request.args.get("source") or _SOURCE_RELEASED).strip().lower()
+    if raw not in _VALID_SOURCES:
+        return _SOURCE_RELEASED
+    return raw
 
 logger = logging.getLogger(__name__)
 
@@ -111,11 +139,20 @@ def _empty_profile() -> dict:
 @legends_bp.route("/legends", methods=["GET"])
 def list_legends():
     """
-    Return all 36 legends sorted alphabetically, each with completion counts.
+    Return all legends sorted alphabetically, each with completion counts.
+
+    Query params:
+      ?source=released (default) — frozen ratings from the active Snapshot
+        Release. Lab Surface — served from released_players. Returns 503
+        no_active_release when no release is published.
+      ?source=draft — in-progress ratings from draft_skill_profiles. Admin
+        Surface — used by /admin/legends editor.
 
     Response data: list of {id, name, peak_era, notes, completion, completion_pct}
     where completion is how many of the 20 skills have been rated.
     """
+    source = _resolve_source()
+
     try:
         supabase = get_supabase()
 
@@ -131,21 +168,47 @@ def list_legends():
         if not legends:
             return _ok([])
 
-        # Fetch all legend skill profiles in one query (is_legend=true, source=manual)
-        # We only need legend_id and the profile JSONB for completion counting
-        profiles_res = (
-            supabase.table("draft_skill_profiles")
-            .select("legend_id, profile")
-            .eq("is_legend", True)
-            .eq("source", "manual")
-            .execute()
-        )
-        # Build lookup: legend_id → profile dict
-        profile_map: dict[str, dict] = {}
-        for row in (profiles_res.data or []):
-            lid = row.get("legend_id")
-            if lid:
-                profile_map[lid] = row.get("profile") or {}
+        # Resolve profile_map: legend_id -> profile dict, from either released
+        # or draft tables based on the requested source.
+        if source == _SOURCE_RELEASED:
+            try:
+                active_release_id = get_active_release_id()
+            except ActiveReleaseMissingError:
+                logger.warning("No active Snapshot Release — cannot serve /api/legends")
+                return jsonify(
+                    {"success": False, "data": None, "error": "no_active_release"}
+                ), 503
+
+            legend_nba_api_ids = [
+                lg["nba_api_id"] for lg in legends if lg.get("nba_api_id") is not None
+            ]
+            profile_by_nba_api_id = fetch_legend_profiles_by_nba_api_ids(
+                legend_nba_api_ids,
+                active_release_id,
+                client=supabase,
+            )
+            # Re-key by legend_id so the completion loop below stays uniform.
+            profile_map: dict[str, dict] = {}
+            for lg in legends:
+                nba_api_id = lg.get("nba_api_id")
+                if nba_api_id is not None:
+                    profile = profile_by_nba_api_id.get(str(nba_api_id))
+                    if profile:
+                        profile_map[lg["id"]] = profile
+        else:
+            # Admin draft path — read from draft_skill_profiles directly.
+            profiles_res = (
+                supabase.table("draft_skill_profiles")
+                .select("legend_id, profile")
+                .eq("is_legend", True)
+                .eq("source", "manual")
+                .execute()
+            )
+            profile_map = {}
+            for row in (profiles_res.data or []):
+                lid = row.get("legend_id")
+                if lid:
+                    profile_map[lid] = row.get("profile") or {}
 
         # Assemble response rows
         result = []
@@ -186,6 +249,13 @@ def get_legend(legend_id: str):
     """
     Return a single legend with full skill profile.
 
+    Query params:
+      ?source=released (default) — frozen ratings from the active Snapshot
+        Release. Lab Surface — served from released_players. Returns 503
+        no_active_release when no release is published.
+      ?source=draft — in-progress ratings from draft_skill_profiles. Admin
+        Surface — used by /admin/legends editor.
+
     If no skill profile exists yet, returns the legend metadata with an empty profile
     (all 20 skills as null — distinct from 'None' which is a deliberate rating).
 
@@ -193,6 +263,8 @@ def get_legend(legend_id: str):
     """
     if not _validate_uuid(legend_id):
         return _err("Invalid legend_id — must be a UUID", status=400)
+
+    source = _resolve_source()
 
     try:
         supabase = get_supabase()
@@ -209,24 +281,46 @@ def get_legend(legend_id: str):
             return _err(f"Legend {legend_id} not found", status=404)
         legend = legend_res.data[0]
 
-        # Fetch skill profile (manual legend profile)
-        profile_res = (
-            supabase.table("draft_skill_profiles")
-            .select("id, profile")
-            .eq("legend_id", legend_id)
-            .eq("is_legend", True)
-            .eq("source", "manual")
-            .limit(1)
-            .execute()
-        )
+        # Resolve the skill profile from either released or draft based on source.
+        if source == _SOURCE_RELEASED:
+            try:
+                active_release_id = get_active_release_id()
+            except ActiveReleaseMissingError:
+                logger.warning(
+                    "No active Snapshot Release — cannot serve /api/legends/%s",
+                    legend_id,
+                )
+                return jsonify(
+                    {"success": False, "data": None, "error": "no_active_release"}
+                ), 503
 
-        if profile_res.data:
-            # Merge stored profile with empty template to ensure all 20 skills are present
-            stored = profile_res.data[0].get("profile") or {}
+            nba_api_id = legend.get("nba_api_id")
+            if nba_api_id is None:
+                stored: dict = {}
+            else:
+                profile_by_nba_api_id = fetch_legend_profiles_by_nba_api_ids(
+                    [nba_api_id],
+                    active_release_id,
+                    client=supabase,
+                )
+                stored = profile_by_nba_api_id.get(str(nba_api_id)) or {}
             profile = {**_empty_profile(), **stored}
         else:
-            # No profile yet — all skills are null (unrated)
-            profile = _empty_profile()
+            # Admin draft path — read from draft_skill_profiles directly.
+            profile_res = (
+                supabase.table("draft_skill_profiles")
+                .select("id, profile")
+                .eq("legend_id", legend_id)
+                .eq("is_legend", True)
+                .eq("source", "manual")
+                .limit(1)
+                .execute()
+            )
+            if profile_res.data:
+                stored = profile_res.data[0].get("profile") or {}
+                profile = {**_empty_profile(), **stored}
+            else:
+                profile = _empty_profile()
 
         rated = _count_rated(profile)
         return _ok({

--- a/backend/api/legends.py
+++ b/backend/api/legends.py
@@ -29,7 +29,7 @@ from services.skills import (
     ALL_SKILLS as _ALL_SKILLS_FROM_MODULE,
     SKILL_DEFINITIONS as _SKILL_DEFINITIONS_FROM_MODULE,
 )
-from services.snapshots_active import (
+from services.snapshot_versions.active import (
     ActiveReleaseMissingError,
     get_active_release_id,
 )

--- a/backend/api/players.py
+++ b/backend/api/players.py
@@ -22,6 +22,14 @@ from flask import Blueprint, jsonify, request
 from services.supabase_client import get_supabase, reset_client
 from services import players_service, nba_api_client
 from services.players_service import CURRENT_SEASON
+from services.snapshots_active import (
+    ActiveReleaseMissingError,
+    get_active_release_id,
+)
+from services.snapshot_versions.released_repo import (
+    fetch_legend_profiles_by_nba_api_ids,
+    fetch_profiles_by_source_player_ids,
+)
 from api.auth import require_admin, require_open_draft
 
 
@@ -451,97 +459,6 @@ def remove_manual_include(player_id: str):
 _LEGEND_SALARY = 54_000_000  # Supermax per project_document.md Rule 1
 
 
-def _fetch_released_profiles(
-    supabase,
-    active_release_id: str,
-    *,
-    source_player_ids: list[str] | None = None,
-    legend_nba_api_ids: list[int] | None = None,
-) -> dict[str, dict]:
-    """Return {source_player_id_or_legend_nba_api_id: skill_profile_snapshot} from released_players.
-
-    Args:
-        supabase: Supabase client.
-        active_release_id: id of the active Snapshot Release.
-        source_player_ids: when set, fetch regular-player rows by source_player_id.
-        legend_nba_api_ids: when set, fetch legend rows (is_legend=true) joined via
-            canonical_players.nba_api_id so callers can match by legend.nba_api_id.
-
-    Returns a plain dict keyed by source_player_id (for players) or nba_api_id cast to
-    str (for legends), mapping to the skill_profile_snapshot dict.
-
-    Raises ValueError if neither or both of source_player_ids/legend_nba_api_ids
-    are provided — the function is a one-mode Surface, not a dispatcher.
-    """
-    if (source_player_ids is None) == (legend_nba_api_ids is None):
-        raise ValueError(
-            "_fetch_released_profiles requires exactly one of "
-            "source_player_ids or legend_nba_api_ids"
-        )
-
-    if source_player_ids is not None:
-        _BATCH = 100
-        result: dict[str, dict] = {}
-        for i in range(0, len(source_player_ids), _BATCH):
-            batch = source_player_ids[i : i + _BATCH]
-            rows = (
-                supabase.table("released_players")
-                .select("source_player_id, skill_profile_snapshot")
-                .eq("snapshot_release_id", active_release_id)
-                .eq("is_legend", False)
-                .in_("source_player_id", batch)
-                # +1 leaves headroom for a future overflow guard to detect
-                # over-full batches; today every batch is bounded by _BATCH.
-                .limit(_BATCH + 1)
-                .execute()
-            )
-            for row in (rows.data or []):
-                pid = row.get("source_player_id")
-                if pid:
-                    result[str(pid)] = row.get("skill_profile_snapshot") or {}
-        return result
-
-    if legend_nba_api_ids is not None:
-        # Legends: released_players.canonical_player_id → canonical_players.nba_api_id
-        # We select canonical_player_id from released_players, then resolve nba_api_id
-        # via a second query on canonical_players.
-        rows = (
-            supabase.table("released_players")
-            .select("canonical_player_id, skill_profile_snapshot")
-            .eq("snapshot_release_id", active_release_id)
-            .eq("is_legend", True)
-            .execute()
-        )
-        released_rows = rows.data or []
-        if not released_rows:
-            return {}
-
-        canonical_ids = [r["canonical_player_id"] for r in released_rows if r.get("canonical_player_id")]
-        if not canonical_ids:
-            return {}
-
-        cp_rows = (
-            supabase.table("canonical_players")
-            .select("id, nba_api_id")
-            .in_("id", canonical_ids)
-            .execute()
-        )
-        canonical_by_id = {
-            row["id"]: row["nba_api_id"]
-            for row in (cp_rows.data or [])
-        }
-
-        result = {}
-        for row in released_rows:
-            cid = row.get("canonical_player_id")
-            nba_api_id = canonical_by_id.get(cid)
-            if nba_api_id is not None:
-                result[str(nba_api_id)] = row.get("skill_profile_snapshot") or {}
-        return result
-
-    return {}
-
-
 def _has_any_rated_skill(profile: dict) -> bool:
     """Return True if the legend profile has at least one non-null skill rating."""
     return any(v is not None for v in profile.values())
@@ -555,9 +472,9 @@ def _fetch_legends_for_bulk() -> list:
     instead of draft_skill_profiles. flag_summary is always {0, 0} on the Lab path.
     Skills are condensed to { skill_name: tier_string } — same shape as current players.
     Nulls (unrated skills) are omitted; 'None' tiers are kept to match current-player parity.
-    """
-    from services.snapshots_active import get_active_release_id, ActiveReleaseMissingError
 
+    Raises ActiveReleaseMissingError; the route-level handler translates to 503.
+    """
     supabase = get_supabase()
 
     # Resolve active release — raises ActiveReleaseMissingError if none exists.
@@ -577,10 +494,10 @@ def _fetch_legends_for_bulk() -> list:
     legend_nba_api_ids = [lg["nba_api_id"] for lg in legends if lg.get("nba_api_id") is not None]
 
     # Read from released_players (active Snapshot Release) — not draft_skill_profiles
-    profile_by_nba_api_id = _fetch_released_profiles(
-        supabase,
+    profile_by_nba_api_id = fetch_legend_profiles_by_nba_api_ids(
+        legend_nba_api_ids,
         active_release_id,
-        legend_nba_api_ids=legend_nba_api_ids,
+        client=supabase,
     )
 
     result = []
@@ -633,9 +550,9 @@ def _fetch_bulk_players(season: str, min_mpg: float) -> list:
     Isolated into a standalone function so the route handler can retry the
     entire sequence on an HTTP/2 connection reset (RemoteProtocolError) by
     simply calling get_supabase() again for a fresh connection pool.
-    """
-    from services.snapshots_active import get_active_release_id
 
+    Raises ActiveReleaseMissingError; the route-level handler translates to 503.
+    """
     supabase = get_supabase()
     active_release_id = get_active_release_id()
 
@@ -662,10 +579,10 @@ def _fetch_bulk_players(season: str, min_mpg: float) -> list:
 
     # 2. Fetch composite skill profiles from released_players (active Snapshot Release).
     #    flag_summary is always {0, 0} — flags are admin/draft-only after M3.
-    profiles_by_player = _fetch_released_profiles(
-        supabase,
+    profiles_by_player = fetch_profiles_by_source_player_ids(
+        player_ids,
         active_release_id,
-        source_player_ids=player_ids,
+        client=supabase,
     )
 
     # 3. Join and build the response list
@@ -727,8 +644,6 @@ def list_players_bulk():
         min_mpg = float(request.args.get("min_mpg", players_service.DEFAULT_MIN_MPG))
     except (ValueError, TypeError):
         return _err("'min_mpg' must be a number", status=400)
-
-    from services.snapshots_active import ActiveReleaseMissingError
 
     try:
         result = _fetch_bulk_players(season, min_mpg)
@@ -1002,17 +917,15 @@ def player_profile(player_id: str):
         # Fetch composite skill profile from released_players (active Snapshot Release).
         # After M3: draft_skill_profiles is admin-only; Lab reads use released_players.
         # flag_summary is always {0, 0} on Lab path — flags are admin/draft-only.
-        from services.snapshots_active import get_active_release_id, ActiveReleaseMissingError
-
         try:
             active_release_id = get_active_release_id()
         except ActiveReleaseMissingError:
             return jsonify({"success": False, "data": None, "error": "no_active_release"}), 503
 
-        profiles = _fetch_released_profiles(
-            supabase,
+        profiles = fetch_profiles_by_source_player_ids(
+            [player_id],
             active_release_id,
-            source_player_ids=[player_id],
+            client=supabase,
         )
         raw_profile = profiles.get(player_id)
 

--- a/backend/api/players.py
+++ b/backend/api/players.py
@@ -22,7 +22,7 @@ from flask import Blueprint, jsonify, request
 from services.supabase_client import get_supabase, reset_client
 from services import players_service, nba_api_client
 from services.players_service import CURRENT_SEASON
-from services.snapshots_active import (
+from services.snapshot_versions.active import (
     ActiveReleaseMissingError,
     get_active_release_id,
 )

--- a/backend/api/players.py
+++ b/backend/api/players.py
@@ -451,6 +451,97 @@ def remove_manual_include(player_id: str):
 _LEGEND_SALARY = 54_000_000  # Supermax per project_document.md Rule 1
 
 
+def _fetch_released_profiles(
+    supabase,
+    active_release_id: str,
+    *,
+    source_player_ids: list[str] | None = None,
+    legend_nba_api_ids: list[int] | None = None,
+) -> dict[str, dict]:
+    """Return {source_player_id_or_legend_nba_api_id: skill_profile_snapshot} from released_players.
+
+    Args:
+        supabase: Supabase client.
+        active_release_id: id of the active Snapshot Release.
+        source_player_ids: when set, fetch regular-player rows by source_player_id.
+        legend_nba_api_ids: when set, fetch legend rows (is_legend=true) joined via
+            canonical_players.nba_api_id so callers can match by legend.nba_api_id.
+
+    Returns a plain dict keyed by source_player_id (for players) or nba_api_id cast to
+    str (for legends), mapping to the skill_profile_snapshot dict.
+
+    Raises ValueError if neither or both of source_player_ids/legend_nba_api_ids
+    are provided — the function is a one-mode Surface, not a dispatcher.
+    """
+    if (source_player_ids is None) == (legend_nba_api_ids is None):
+        raise ValueError(
+            "_fetch_released_profiles requires exactly one of "
+            "source_player_ids or legend_nba_api_ids"
+        )
+
+    if source_player_ids is not None:
+        _BATCH = 100
+        result: dict[str, dict] = {}
+        for i in range(0, len(source_player_ids), _BATCH):
+            batch = source_player_ids[i : i + _BATCH]
+            rows = (
+                supabase.table("released_players")
+                .select("source_player_id, skill_profile_snapshot")
+                .eq("snapshot_release_id", active_release_id)
+                .eq("is_legend", False)
+                .in_("source_player_id", batch)
+                # +1 leaves headroom for a future overflow guard to detect
+                # over-full batches; today every batch is bounded by _BATCH.
+                .limit(_BATCH + 1)
+                .execute()
+            )
+            for row in (rows.data or []):
+                pid = row.get("source_player_id")
+                if pid:
+                    result[str(pid)] = row.get("skill_profile_snapshot") or {}
+        return result
+
+    if legend_nba_api_ids is not None:
+        # Legends: released_players.canonical_player_id → canonical_players.nba_api_id
+        # We select canonical_player_id from released_players, then resolve nba_api_id
+        # via a second query on canonical_players.
+        rows = (
+            supabase.table("released_players")
+            .select("canonical_player_id, skill_profile_snapshot")
+            .eq("snapshot_release_id", active_release_id)
+            .eq("is_legend", True)
+            .execute()
+        )
+        released_rows = rows.data or []
+        if not released_rows:
+            return {}
+
+        canonical_ids = [r["canonical_player_id"] for r in released_rows if r.get("canonical_player_id")]
+        if not canonical_ids:
+            return {}
+
+        cp_rows = (
+            supabase.table("canonical_players")
+            .select("id, nba_api_id")
+            .in_("id", canonical_ids)
+            .execute()
+        )
+        canonical_by_id = {
+            row["id"]: row["nba_api_id"]
+            for row in (cp_rows.data or [])
+        }
+
+        result = {}
+        for row in released_rows:
+            cid = row.get("canonical_player_id")
+            nba_api_id = canonical_by_id.get(cid)
+            if nba_api_id is not None:
+                result[str(nba_api_id)] = row.get("skill_profile_snapshot") or {}
+        return result
+
+    return {}
+
+
 def _has_any_rated_skill(profile: dict) -> bool:
     """Return True if the legend profile has at least one non-null skill rating."""
     return any(v is not None for v in profile.values())
@@ -460,11 +551,17 @@ def _fetch_legends_for_bulk() -> list:
     """
     Return legends that have at least one rated skill, shaped as PlayerWithSkills dicts.
 
-    Legends are identified by is_legend=True, source='manual' in draft_skill_profiles.
+    After M3: reads skill_profile_snapshot from released_players (active Snapshot Release)
+    instead of draft_skill_profiles. flag_summary is always {0, 0} on the Lab path.
     Skills are condensed to { skill_name: tier_string } — same shape as current players.
     Nulls (unrated skills) are omitted; 'None' tiers are kept to match current-player parity.
     """
+    from services.snapshots_active import get_active_release_id, ActiveReleaseMissingError
+
     supabase = get_supabase()
+
+    # Resolve active release — raises ActiveReleaseMissingError if none exists.
+    active_release_id = get_active_release_id()
 
     # Fetch all legends with their physical attributes
     legends_res = (
@@ -477,27 +574,19 @@ def _fetch_legends_for_bulk() -> list:
     if not legends:
         return []
 
-    legend_ids = [lg["id"] for lg in legends]
+    legend_nba_api_ids = [lg["nba_api_id"] for lg in legends if lg.get("nba_api_id") is not None]
 
-    # Fetch manual skill profiles for all legends in one query
-    profiles_res = (
-        supabase.table("draft_skill_profiles")
-        .select("legend_id, profile")
-        .in_("legend_id", legend_ids)
-        .eq("is_legend", True)
-        .eq("source", "manual")
-        .execute()
+    # Read from released_players (active Snapshot Release) — not draft_skill_profiles
+    profile_by_nba_api_id = _fetch_released_profiles(
+        supabase,
+        active_release_id,
+        legend_nba_api_ids=legend_nba_api_ids,
     )
-    profile_by_legend: dict = {
-        row["legend_id"]: row.get("profile") or {}
-        for row in (profiles_res.data or [])
-        if row.get("legend_id")
-    }
 
     result = []
     for legend in legends:
-        lid = legend["id"]
-        raw_profile = profile_by_legend.get(lid, {})
+        nba_api_id = legend.get("nba_api_id")
+        raw_profile = profile_by_nba_api_id.get(str(nba_api_id), {}) if nba_api_id else {}
 
         # Skip legends with no rated skills
         if not _has_any_rated_skill(raw_profile):
@@ -505,13 +594,13 @@ def _fetch_legends_for_bulk() -> list:
 
         # Condense profile: omit null (unrated) keys, keep deliberate 'None' tier values
         skills = {
-            skill: tier
-            for skill, tier in raw_profile.items()
-            if tier is not None
+            skill: (details.get("final_tier") if isinstance(details, dict) else details)
+            for skill, details in raw_profile.items()
+            if (details.get("final_tier") if isinstance(details, dict) else details) is not None
         }
 
         result.append({
-            "id":               lid,
+            "id":               legend["id"],
             "name":             legend["name"],
             "team":             legend.get("team"),
             "position":         legend.get("position"),
@@ -524,7 +613,7 @@ def _fetch_legends_for_bulk() -> list:
             "season":           "Legends",
             "is_legend":        True,
             "peak_year":        legend.get("peak_year"),
-            "nba_api_id":       legend.get("nba_api_id"),
+            "nba_api_id":       nba_api_id,
             "skills":           skills,
             "flag_summary":     {"total": 0, "unresolved": 0},
         })
@@ -534,14 +623,21 @@ def _fetch_legends_for_bulk() -> list:
 
 def _fetch_bulk_players(season: str, min_mpg: float) -> list:
     """
-    Execute all three Supabase queries needed for the bulk players response
-    (players → draft_skill_profiles → draft_skill_flags) and join them in Python.
+    Execute the queries needed for the bulk players response
+    (players → released_players for active Snapshot Release) and join them in Python.
+
+    After M3: reads composite profiles from released_players (active Snapshot Release)
+    instead of draft_skill_profiles + draft_skill_flags. flag_summary is always
+    {total: 0, unresolved: 0} on the Lab path — flags are admin/draft-only.
 
     Isolated into a standalone function so the route handler can retry the
     entire sequence on an HTTP/2 connection reset (RemoteProtocolError) by
     simply calling get_supabase() again for a fresh connection pool.
     """
+    from services.snapshots_active import get_active_release_id
+
     supabase = get_supabase()
+    active_release_id = get_active_release_id()
 
     # 1. Fetch all qualifying players for this season.
     # Include players that meet the MPG threshold OR were manually added
@@ -564,83 +660,31 @@ def _fetch_bulk_players(season: str, min_mpg: float) -> list:
 
     player_ids = [p["id"] for p in players_data]
 
-    # 2. Fetch composite skill profiles — chunked in batches of 100 to stay
-    #    within PostgREST URL length limits (~8 KB default in most proxies).
-    _BATCH = 100
-    profiles_data: list = []
-    for i in range(0, len(player_ids), _BATCH):
-        batch = player_ids[i : i + _BATCH]
-        rows = (
-            supabase.table("draft_skill_profiles")
-            .select("id, player_id, profile")
-            .in_("player_id", batch)
-            .eq("season", season)
-            .eq("source", "composite")
-            .limit(_BATCH + 1)  # +1 lets us detect unexpected overflow
-            .execute()
-        )
-        profiles_data.extend(rows.data or [])
+    # 2. Fetch composite skill profiles from released_players (active Snapshot Release).
+    #    flag_summary is always {0, 0} — flags are admin/draft-only after M3.
+    profiles_by_player = _fetch_released_profiles(
+        supabase,
+        active_release_id,
+        source_player_ids=player_ids,
+    )
 
-    # Index profiles by player_id for O(1) lookup
-    profiles_by_player: dict = {}
-    profile_id_to_player_id: dict = {}
-    for row in profiles_data:
-        profiles_by_player[row["player_id"]] = row
-        profile_id_to_player_id[row["id"]] = row["player_id"]
-
-    # 3. Fetch flag counts — chunked by the same batch size.
-    #    Counts are accumulated in Python; we log a warning if any batch hits
-    #    the limit, which would signal silent truncation of flag counts.
-    profile_ids = list(profile_id_to_player_id.keys())
-    flags_by_profile_id: dict = {}
-    _FLAG_BATCH_LIMIT = 1000  # per-batch row ceiling
-    if profile_ids:
-        for i in range(0, len(profile_ids), _BATCH):
-            batch = profile_ids[i : i + _BATCH]
-            flags_rows = (
-                supabase.table("draft_skill_flags")
-                .select("skill_profile_id, resolution")
-                .in_("skill_profile_id", batch)
-                .limit(_FLAG_BATCH_LIMIT)
-                .execute()
-            )
-            flags_batch = flags_rows.data or []
-            if len(flags_batch) >= _FLAG_BATCH_LIMIT:
-                logger.warning(
-                    "Flag batch hit row limit (%d) — flag counts may be understated. "
-                    "Consider aggregating via an RPC instead.",
-                    _FLAG_BATCH_LIMIT,
-                )
-            for flag in flags_batch:
-                pid = flag["skill_profile_id"]
-                if pid not in flags_by_profile_id:
-                    flags_by_profile_id[pid] = {"total": 0, "unresolved": 0}
-                flags_by_profile_id[pid]["total"] += 1
-                if flag.get("resolution") is None:
-                    flags_by_profile_id[pid]["unresolved"] += 1
-
-    # 4. Join everything and build the response list
+    # 3. Join and build the response list
     result = []
     for player in players_data:
-        profile_row = profiles_by_player.get(player["id"])
+        raw_profile = profiles_by_player.get(player["id"])
         skills = None
-        flag_summary = {"total": 0, "unresolved": 0}
 
-        if profile_row:
-            raw_profile = profile_row.get("profile") or {}
+        if raw_profile is not None:
             # Condense to just final_tier per skill — keeps payload light
             skills = {
                 skill: (details.get("final_tier") if isinstance(details, dict) else details)
                 for skill, details in raw_profile.items()
             }
-            flag_summary = flags_by_profile_id.get(
-                profile_row["id"], {"total": 0, "unresolved": 0}
-            )
 
         result.append({
             **player,
             "skills": skills,
-            "flag_summary": flag_summary,
+            "flag_summary": {"total": 0, "unresolved": 0},
             "is_rookie_deal": (
                 player.get("draft_round") == 1
                 and (player.get("season_exp") or 99) <= 3
@@ -684,11 +728,16 @@ def list_players_bulk():
     except (ValueError, TypeError):
         return _err("'min_mpg' must be a number", status=400)
 
+    from services.snapshots_active import ActiveReleaseMissingError
+
     try:
         result = _fetch_bulk_players(season, min_mpg)
         if include_legends:
             result = result + _fetch_legends_for_bulk()
         return _ok(result)
+    except ActiveReleaseMissingError:
+        logger.warning("No active Snapshot Release — cannot serve /api/players/bulk")
+        return jsonify({"success": False, "data": None, "error": "no_active_release"}), 503
     except (httpx.ReadError, httpx.RemoteProtocolError) as exc:
         # Supabase PostgREST closes HTTP/2 connections after ~34 streams
         # (GOAWAY frame). Reset the singleton so the retry gets a fresh pool.
@@ -703,6 +752,11 @@ def list_players_bulk():
             if include_legends:
                 result = result + _fetch_legends_for_bulk()
             return _ok(result)
+        except ActiveReleaseMissingError:
+            logger.warning(
+                "No active Snapshot Release on retry — cannot serve /api/players/bulk"
+            )
+            return jsonify({"success": False, "data": None, "error": "no_active_release"}), 503
         except Exception as retry_exc:
             logger.exception("Error in GET /api/players/bulk (retry also failed)")
             return _err(str(retry_exc))
@@ -945,39 +999,25 @@ def player_profile(player_id: str):
             return _err(f"Player {player_id} not found for season {season}", status=404)
         player = player_row.data[0]
 
-        # Fetch composite skill profile (if it exists)
-        profile_row = (
-            supabase.table("draft_skill_profiles")
-            .select("id, profile")
-            .eq("player_id", player_id)
-            .eq("season", season)
-            .eq("source", "composite")
-            .limit(1)
-            .execute()
+        # Fetch composite skill profile from released_players (active Snapshot Release).
+        # After M3: draft_skill_profiles is admin-only; Lab reads use released_players.
+        # flag_summary is always {0, 0} on Lab path — flags are admin/draft-only.
+        from services.snapshots_active import get_active_release_id, ActiveReleaseMissingError
+
+        try:
+            active_release_id = get_active_release_id()
+        except ActiveReleaseMissingError:
+            return jsonify({"success": False, "data": None, "error": "no_active_release"}), 503
+
+        profiles = _fetch_released_profiles(
+            supabase,
+            active_release_id,
+            source_player_ids=[player_id],
         )
+        raw_profile = profiles.get(player_id)
 
-        skills_data = None
+        skills_data = raw_profile if raw_profile else None
         flag_summary = {"total": 0, "unresolved": 0}
-        composite_profile_id = None
-
-        if profile_row.data:
-            composite_profile_id = profile_row.data[0]["id"]
-            raw_profile = profile_row.data[0]["profile"] or {}
-            # Return the full composite result dict per skill so the UI can show
-            # stat_tier, claude_tier, source, and flagged state
-            skills_data = raw_profile
-
-            # Fetch flag summary counts
-            flag_rows = (
-                supabase.table("draft_skill_flags")
-                .select("id, resolution")
-                .eq("skill_profile_id", composite_profile_id)
-                .execute()
-            )
-            all_flags     = flag_rows.data or []
-            total_flags   = len(all_flags)
-            unresolved    = sum(1 for f in all_flags if f.get("resolution") is None)
-            flag_summary  = {"total": total_flags, "unresolved": unresolved}
 
         return _ok({
             "player":       player,

--- a/backend/services/cohesion_engine/composites.py
+++ b/backend/services/cohesion_engine/composites.py
@@ -365,7 +365,7 @@ def build_distributions(season: str, values: dict[str, Any]) -> dict[str, list[f
     receive the small distribution, but normalization falls back to theoretical
     maxima until the cache has enough population data.
     """
-    from services.snapshots_active import get_active_release_id, ActiveReleaseMissingError
+    from services.snapshot_versions.active import get_active_release_id, ActiveReleaseMissingError
 
     client = _get_supabase_client()
     all_raw: dict[str, list[float]] = {name: [] for name in COMPOSITE_NAMES}

--- a/backend/services/cohesion_engine/composites.py
+++ b/backend/services/cohesion_engine/composites.py
@@ -355,35 +355,56 @@ def build_distributions(season: str, values: dict[str, Any]) -> dict[str, list[f
     """
     Build and cache raw composite distributions for current players + legends.
 
+    After M3: reads from released_players (active Snapshot Release) instead of
+    draft_skill_profiles. Both regular-player and legend profiles are sourced from
+    skill_profile_snapshot column. If no active release exists, logs and degrades
+    gracefully to an empty distribution (existing MIN_DISTRIBUTION_SIZE fallback
+    handles the theoretical-max path).
+
     If fewer than MIN_DISTRIBUTION_SIZE player profiles exist, callers will still
     receive the small distribution, but normalization falls back to theoretical
     maxima until the cache has enough population data.
     """
+    from services.snapshots_active import get_active_release_id, ActiveReleaseMissingError
+
     client = _get_supabase_client()
     all_raw: dict[str, list[float]] = {name: [] for name in COMPOSITE_NAMES}
 
+    try:
+        active_release_id = get_active_release_id(client=client)
+    except ActiveReleaseMissingError:
+        logger.warning(
+            "build_distributions: no active Snapshot Release — "
+            "returning empty distributions (theoretical fallback will be used)"
+        )
+        distributions: dict[str, list[float]] = {name: [] for name in COMPOSITE_NAMES}
+        set_distributions(distributions)
+        return distributions
+
+    # Regular players — source_player_id is non-null, is_legend=false
     profiles = _run_query(
-        lambda: client.table("draft_skill_profiles")
-        .select("profile")
-        .eq("season", season)
-        .eq("source", "composite")
+        lambda: client.table("released_players")
+        .select("skill_profile_snapshot")
+        .eq("snapshot_release_id", active_release_id)
+        .eq("is_legend", False)
         .execute()
     )
     for row in profiles.data:
-        skills = _with_default_skills(_extract_skills(row["profile"]))
+        skills = _with_default_skills(_extract_skills(row["skill_profile_snapshot"] or {}))
         raw = compute_raw_composites(skills, values)
         for name, value in raw.items():
             all_raw[name].append(value)
 
+    # Legends — is_legend=true; composite already frozen at publish
     legend_profiles = _run_query(
-        lambda: client.table("draft_skill_profiles")
-        .select("profile")
-        .eq("source", "manual")
+        lambda: client.table("released_players")
+        .select("skill_profile_snapshot")
+        .eq("snapshot_release_id", active_release_id)
         .eq("is_legend", True)
         .execute()
     )
     for row in legend_profiles.data:
-        skills = _with_default_skills(_extract_skills(row["profile"]))
+        skills = _with_default_skills(_extract_skills(row["skill_profile_snapshot"] or {}))
         raw = compute_raw_composites(skills, values)
         for name, value in raw.items():
             all_raw[name].append(value)

--- a/backend/services/snapshot_versions/__init__.py
+++ b/backend/services/snapshot_versions/__init__.py
@@ -1,1 +1,8 @@
 """Snapshot Version lifecycle services."""
+
+from services.snapshot_versions.active import (
+    ActiveReleaseMissingError,
+    get_active_release_id,
+)
+
+__all__ = ["ActiveReleaseMissingError", "get_active_release_id"]

--- a/backend/services/snapshot_versions/active.py
+++ b/backend/services/snapshot_versions/active.py
@@ -1,5 +1,5 @@
 """
-services/snapshots_active.py — per-request memoization Seam for the active Snapshot Release.
+services/snapshot_versions/active.py — per-request memoization Seam for the active Snapshot Release.
 
 Wraps snapshot_versions.repo.get_active_release so all Lab read paths share one
 cached lookup per Flask request. Cohesion warmup (no request context) calls this

--- a/backend/services/snapshot_versions/released_repo.py
+++ b/backend/services/snapshot_versions/released_repo.py
@@ -8,7 +8,7 @@ data should go through this module; admin Surfaces continue to read
 draft_skill_profiles directly via their own paths.
 
 All queries filter by `snapshot_release_id = active_release_id`. Callers obtain
-the active release id via services.snapshots_active.get_active_release_id().
+the active release id via services.snapshot_versions.active.get_active_release_id().
 """
 
 from __future__ import annotations

--- a/backend/services/snapshot_versions/released_repo.py
+++ b/backend/services/snapshot_versions/released_repo.py
@@ -1,0 +1,122 @@
+"""
+services/snapshot_versions/released_repo.py — Lab-side read helpers for released_players.
+
+Centralizes the released-players read Contract introduced in M3 so future Lab
+Surfaces share one Seam instead of re-rolling the query against
+draft_skill_profiles by mistake. Every Lab Surface that needs Skill Profile
+data should go through this module; admin Surfaces continue to read
+draft_skill_profiles directly via their own paths.
+
+All queries filter by `snapshot_release_id = active_release_id`. Callers obtain
+the active release id via services.snapshots_active.get_active_release_id().
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+_BATCH = 100
+_LEGENDS_QUERY_LIMIT = 500  # legends ~36 today; ceiling guards against silent truncation
+
+
+def fetch_profiles_by_source_player_ids(
+    source_player_ids: Iterable[str],
+    active_release_id: str,
+    *,
+    client=None,
+) -> dict[str, dict]:
+    """Return {source_player_id: skill_profile_snapshot} for the given Player ids
+    in the active Snapshot Release.
+
+    Batches into chunks of 100 to stay inside PostgREST URL limits. Each batch
+    issues a `.limit(_BATCH + 1)` so a future overflow guard can detect
+    over-full batches.
+    """
+    from services.supabase_client import get_supabase
+
+    ids = [pid for pid in source_player_ids if pid]
+    if not ids:
+        return {}
+
+    c = client or get_supabase()
+    result: dict[str, dict] = {}
+    for i in range(0, len(ids), _BATCH):
+        batch = ids[i : i + _BATCH]
+        rows = (
+            c.table("released_players")
+            .select("source_player_id, skill_profile_snapshot")
+            .eq("snapshot_release_id", active_release_id)
+            .eq("is_legend", False)
+            .in_("source_player_id", batch)
+            .limit(_BATCH + 1)
+            .execute()
+        )
+        for row in (rows.data or []):
+            pid = row.get("source_player_id")
+            if pid:
+                result[str(pid)] = row.get("skill_profile_snapshot") or {}
+    return result
+
+
+def fetch_legend_profiles_by_nba_api_ids(
+    legend_nba_api_ids: Iterable[int] | None,
+    active_release_id: str,
+    *,
+    client=None,
+) -> dict[str, dict]:
+    """Return {nba_api_id_str: skill_profile_snapshot} for legend rows in the
+    active Snapshot Release.
+
+    released_players has no legend_id; the join chain is:
+        released_players.canonical_player_id -> canonical_players.id
+        canonical_players.nba_api_id          <- caller's filter
+
+    If legend_nba_api_ids is None, returns every legend row in the active
+    release. When a filter is supplied, it is pushed down to the
+    canonical_players query so only matching rows return.
+    """
+    from services.supabase_client import get_supabase
+
+    c = client or get_supabase()
+
+    rows = (
+        c.table("released_players")
+        .select("canonical_player_id, skill_profile_snapshot")
+        .eq("snapshot_release_id", active_release_id)
+        .eq("is_legend", True)
+        .limit(_LEGENDS_QUERY_LIMIT)
+        .execute()
+    )
+    released_rows = rows.data or []
+    if not released_rows:
+        return {}
+
+    canonical_ids = [
+        r["canonical_player_id"] for r in released_rows if r.get("canonical_player_id")
+    ]
+    if not canonical_ids:
+        return {}
+
+    cp_query = (
+        c.table("canonical_players")
+        .select("id, nba_api_id")
+        .in_("id", canonical_ids)
+    )
+    if legend_nba_api_ids is not None:
+        wanted = [n for n in legend_nba_api_ids if n is not None]
+        if not wanted:
+            return {}
+        cp_query = cp_query.in_("nba_api_id", wanted)
+
+    cp_rows = cp_query.limit(_LEGENDS_QUERY_LIMIT).execute()
+    canonical_by_id = {
+        row["id"]: row["nba_api_id"] for row in (cp_rows.data or [])
+    }
+
+    result: dict[str, dict] = {}
+    for row in released_rows:
+        cid = row.get("canonical_player_id")
+        nba_api_id = canonical_by_id.get(cid)
+        if nba_api_id is not None:
+            result[str(nba_api_id)] = row.get("skill_profile_snapshot") or {}
+    return result

--- a/backend/services/snapshots_active.py
+++ b/backend/services/snapshots_active.py
@@ -52,15 +52,28 @@ def get_active_release_id(client=None) -> str:
 
 
 def _query_active_release_id(client=None) -> str:
-    """Execute the DB query — one level of indirection so tests can patch cheaply."""
+    """Execute the DB query — one level of indirection so tests can patch cheaply.
+
+    Only translates the no-active-release path into ActiveReleaseMissingError.
+    Unexpected exceptions (network timeouts, auth failures, config errors)
+    propagate so operators see a 500 with a real stack trace instead of being
+    misdiagnosed as a missing release.
+    """
+    from postgrest.exceptions import APIError
+
     from services.snapshot_versions.repo import get_active_release
 
     try:
         release = get_active_release(client)
-    except Exception as exc:
-        raise ActiveReleaseMissingError(
-            "No active Snapshot Release found — cannot serve Lab reads"
-        ) from exc
+    except APIError as exc:
+        # PostgREST returns PGRST116 when `.single()` finds zero rows. That is
+        # the canonical "no active release" signal. Other APIError codes
+        # (auth, schema, syntax) propagate untouched.
+        if getattr(exc, "code", None) == "PGRST116" or "PGRST116" in str(exc):
+            raise ActiveReleaseMissingError(
+                "No active Snapshot Release found — cannot serve Lab reads"
+            ) from exc
+        raise
 
     if not release or not release.id:
         raise ActiveReleaseMissingError(

--- a/backend/services/snapshots_active.py
+++ b/backend/services/snapshots_active.py
@@ -1,0 +1,70 @@
+"""
+services/snapshots_active.py — per-request memoization Seam for the active Snapshot Release.
+
+Wraps snapshot_versions.repo.get_active_release so all Lab read paths share one
+cached lookup per Flask request. Cohesion warmup (no request context) calls this
+with an explicit client and gets the result without memoization.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import flask
+
+logger = logging.getLogger(__name__)
+
+_G_KEY = "_active_release_id"
+
+
+class ActiveReleaseMissingError(RuntimeError):
+    """Raised when no snapshot_releases row has is_active=true."""
+
+
+def get_active_release_id(client=None) -> str:
+    """Return the id of the active Snapshot Release.
+
+    Memoized via flask.g when called inside a request context so repeated
+    calls within one request hit the cache. Falls through to a live DB query
+    when called outside a request context (e.g. cohesion warmup at boot).
+
+    Args:
+        client: optional Supabase client to use for the DB query. When None
+                the default get_supabase() client is used. Accepted here so
+                callers that already hold a client avoid creating a second one.
+
+    Raises:
+        ActiveReleaseMissingError: no active release found.
+    """
+    # Memoize inside a request context only
+    in_request = flask.has_request_context()
+    if in_request:
+        cached = flask.g.get(_G_KEY)
+        if cached is not None:
+            return cached
+
+    release_id = _query_active_release_id(client)
+
+    if in_request:
+        setattr(flask.g, _G_KEY, release_id)
+
+    return release_id
+
+
+def _query_active_release_id(client=None) -> str:
+    """Execute the DB query — one level of indirection so tests can patch cheaply."""
+    from services.snapshot_versions.repo import get_active_release
+
+    try:
+        release = get_active_release(client)
+    except Exception as exc:
+        raise ActiveReleaseMissingError(
+            "No active Snapshot Release found — cannot serve Lab reads"
+        ) from exc
+
+    if not release or not release.id:
+        raise ActiveReleaseMissingError(
+            "No active Snapshot Release found — cannot serve Lab reads"
+        )
+
+    return release.id

--- a/backend/tests/test_cohesion_engine/test_composites.py
+++ b/backend/tests/test_cohesion_engine/test_composites.py
@@ -201,10 +201,10 @@ def test_normalize_composites_guards_zero_theoretical_max():
 
 def test_build_distributions_reads_current_and_legend_profiles(monkeypatch):
     """After M3: build_distributions reads released_players.skill_profile_snapshot,
-    not draft_skill_profiles.profile. Patching snapshots_active so the active-release
+    not draft_skill_profiles.profile. Patching snapshot_versions.active so the active-release
     guard succeeds without a live DB.
     """
-    import services.snapshots_active as snapshots_active_mod
+    import services.snapshot_versions.active as snapshots_active_mod
 
     FAKE_RELEASE_ID = "fake-release-id"
 

--- a/backend/tests/test_cohesion_engine/test_composites.py
+++ b/backend/tests/test_cohesion_engine/test_composites.py
@@ -200,6 +200,14 @@ def test_normalize_composites_guards_zero_theoretical_max():
 
 
 def test_build_distributions_reads_current_and_legend_profiles(monkeypatch):
+    """After M3: build_distributions reads released_players.skill_profile_snapshot,
+    not draft_skill_profiles.profile. Patching snapshots_active so the active-release
+    guard succeeds without a live DB.
+    """
+    import services.snapshots_active as snapshots_active_mod
+
+    FAKE_RELEASE_ID = "fake-release-id"
+
     class FakeResult:
         def __init__(self, data):
             self.data = data
@@ -216,12 +224,13 @@ def test_build_distributions_reads_current_and_legend_profiles(monkeypatch):
             return self
 
         def execute(self):
+            # Return skill_profile_snapshot (released_players column, not profile)
             if self.filters.get("is_legend") is True:
                 return FakeResult(
-                    [{"profile": {"movement_shooter": {"final_tier": "Capable"}}}]
+                    [{"skill_profile_snapshot": {"movement_shooter": {"final_tier": "Capable"}}}]
                 )
             return FakeResult(
-                [{"profile": {"spot_up_shooter": {"final_tier": "Elite"}}}]
+                [{"skill_profile_snapshot": {"spot_up_shooter": {"final_tier": "Elite"}}}]
             )
 
     class FakeClient:
@@ -230,6 +239,12 @@ def test_build_distributions_reads_current_and_legend_profiles(monkeypatch):
 
     monkeypatch.setattr(composites, "_get_supabase_client", lambda: FakeClient())
     monkeypatch.setattr(composites, "_run_query", lambda query: query())
+    # Patch the active-release lookup so the guard passes without a live DB
+    monkeypatch.setattr(
+        snapshots_active_mod,
+        "_query_active_release_id",
+        lambda client=None: FAKE_RELEASE_ID,
+    )
 
     distributions = composites.build_distributions("2025-26", VALUES)
 

--- a/backend/tests/test_lab_read_pin.py
+++ b/backend/tests/test_lab_read_pin.py
@@ -228,7 +228,7 @@ def test_draft_edit_does_not_leak_to_lab_player_detail(app):
     with (
         patch("api.players.get_supabase", return_value=supabase),
         patch(
-            "services.snapshots_active.get_active_release_id",
+            "api.players.get_active_release_id",
             return_value=ACTIVE_RELEASE_ID,
         ),
     ):
@@ -339,7 +339,7 @@ def test_draft_edit_does_not_leak_to_bulk_players_list(app):
     with (
         patch("api.players.get_supabase", return_value=supabase),
         patch(
-            "services.snapshots_active.get_active_release_id",
+            "api.players.get_active_release_id",
             return_value=ACTIVE_RELEASE_ID,
         ),
     ):
@@ -384,7 +384,7 @@ def test_draft_edit_does_not_leak_to_legends_listing(app):
     with (
         patch("api.players.get_supabase", return_value=supabase),
         patch(
-            "services.snapshots_active.get_active_release_id",
+            "api.players.get_active_release_id",
             return_value=ACTIVE_RELEASE_ID,
         ),
     ):
@@ -526,7 +526,7 @@ def test_player_detail_returns_503_when_no_active_release(app):
     with (
         patch("api.players.get_supabase", return_value=supabase),
         patch(
-            "services.snapshots_active.get_active_release_id",
+            "api.players.get_active_release_id",
             side_effect=ActiveReleaseMissingError("no active release"),
         ),
     ):
@@ -535,6 +535,211 @@ def test_player_detail_returns_503_when_no_active_release(app):
                 f"/api/players/{PLAYER_ID}/profile",
                 query_string={"season": SEASON},
             )
+
+    assert resp.status_code == 503
+    body = resp.get_json()
+    assert body["success"] is False
+    assert "no_active_release" in body["error"]
+
+
+# ---------------------------------------------------------------------------
+# /api/legends Lab Surface — released by default, ?source=draft for admin
+# ---------------------------------------------------------------------------
+
+
+def _make_supabase_for_legends_route(
+    legend_released_profile: dict,
+    legend_draft_profile: dict,
+) -> MagicMock:
+    """Build a Supabase mock that serves the /api/legends list and detail routes.
+
+    Both released_players (Lab path) and draft_skill_profiles (admin path)
+    return populated profiles with DISTINCT tier values so a leak is caught
+    immediately by the assertion.
+    """
+    supabase = MagicMock()
+
+    def table_side_effect(name: str):
+        q = MagicMock()
+        q.select.return_value = q
+        q.eq.return_value = q
+        q.in_.return_value = q
+        q.or_.return_value = q
+        q.order.return_value = q
+        q.limit.return_value = q
+        q.single.return_value = q
+
+        if name == "legends":
+            q.execute.return_value = _FakeResult([{
+                "id": LEGEND_ID,
+                "name": "Hakeem Olajuwon",
+                "peak_era": "1990s",
+                "notes": None,
+                "team": None,
+                "position": "C",
+                "age": None,
+                "height": 84,
+                "weight": 255,
+                "peak_year": 1994,
+                "nba_api_id": NBA_API_ID,
+            }])
+        elif name == "released_players":
+            q.execute.return_value = _FakeResult([{
+                "canonical_player_id": CANONICAL_PLAYER_ID,
+                "skill_profile_snapshot": legend_released_profile,
+            }])
+        elif name == "canonical_players":
+            q.execute.return_value = _FakeResult([{
+                "id": CANONICAL_PLAYER_ID,
+                "nba_api_id": NBA_API_ID,
+            }])
+        elif name == "draft_skill_profiles":
+            q.execute.return_value = _FakeResult([{
+                "id": "dsp-legend-001",
+                "legend_id": LEGEND_ID,
+                "is_legend": True,
+                "source": "manual",
+                "profile": legend_draft_profile,
+            }])
+        else:
+            q.execute.return_value = _FakeResult([])
+
+        return q
+
+    supabase.table.side_effect = table_side_effect
+    return supabase
+
+
+def test_lab_legends_list_does_not_leak_draft_edits(app):
+    """GET /api/legends (no source param) defaults to released — draft edits invisible."""
+    supabase = _make_supabase_for_legends_route(
+        legend_released_profile=RELEASED_LEGEND_PROFILE,
+        legend_draft_profile=DRAFT_MUTATED_LEGEND_PROFILE,
+    )
+
+    with (
+        patch("api.legends.get_supabase", return_value=supabase),
+        patch(
+            "api.legends.get_active_release_id",
+            return_value=ACTIVE_RELEASE_ID,
+        ),
+    ):
+        with app.test_client() as client:
+            resp = client.get("/api/legends")
+
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["success"] is True
+
+    # Completion count derives from the profile contents — released profile has
+    # 2 rated skills, draft mutated has 2 rated. Both equal here, so check the
+    # `released_players` table was consulted and `draft_skill_profiles` was not.
+    table_calls = [c.args[0] for c in supabase.table.call_args_list]
+    assert "released_players" in table_calls, (
+        f"/api/legends did NOT read released_players — table_calls={table_calls}"
+    )
+    assert "draft_skill_profiles" not in table_calls, (
+        "/api/legends leaked into draft_skill_profiles when source defaulted to released "
+        f"— table_calls={table_calls}"
+    )
+
+
+def test_lab_legends_detail_does_not_leak_draft_edits(app):
+    """GET /api/legends/<id> (no source param) defaults to released — draft edits invisible."""
+    supabase = _make_supabase_for_legends_route(
+        legend_released_profile=RELEASED_LEGEND_PROFILE,
+        legend_draft_profile=DRAFT_MUTATED_LEGEND_PROFILE,
+    )
+
+    with (
+        patch("api.legends.get_supabase", return_value=supabase),
+        patch(
+            "api.legends.get_active_release_id",
+            return_value=ACTIVE_RELEASE_ID,
+        ),
+    ):
+        with app.test_client() as client:
+            resp = client.get(f"/api/legends/{LEGEND_ID}")
+
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["success"] is True
+
+    # Scorer must reflect released "Elite", not draft mutated "Capable".
+    profile = body["data"]["profile"]
+    assert profile.get("Scorer") == "Elite", (
+        f"Expected released Scorer=Elite, got {profile.get('Scorer')!r} — draft leak detected"
+    )
+
+    table_calls = [c.args[0] for c in supabase.table.call_args_list]
+    assert "draft_skill_profiles" not in table_calls, (
+        f"/api/legends/{LEGEND_ID} leaked into draft_skill_profiles — table_calls={table_calls}"
+    )
+
+
+def test_admin_legends_list_reads_draft_when_source_draft(app):
+    """GET /api/legends?source=draft reads draft_skill_profiles (admin Surface)."""
+    supabase = _make_supabase_for_legends_route(
+        legend_released_profile=RELEASED_LEGEND_PROFILE,
+        legend_draft_profile=DRAFT_MUTATED_LEGEND_PROFILE,
+    )
+
+    with patch("api.legends.get_supabase", return_value=supabase):
+        with app.test_client() as client:
+            resp = client.get("/api/legends?source=draft")
+
+    assert resp.status_code == 200, resp.get_json()
+
+    table_calls = [c.args[0] for c in supabase.table.call_args_list]
+    assert "draft_skill_profiles" in table_calls, (
+        f"/api/legends?source=draft did NOT read draft tables — table_calls={table_calls}"
+    )
+    assert "released_players" not in table_calls, (
+        f"/api/legends?source=draft leaked into released_players — table_calls={table_calls}"
+    )
+
+
+def test_admin_legends_detail_reads_draft_when_source_draft(app):
+    """GET /api/legends/<id>?source=draft reads draft_skill_profiles."""
+    supabase = _make_supabase_for_legends_route(
+        legend_released_profile=RELEASED_LEGEND_PROFILE,
+        legend_draft_profile=DRAFT_MUTATED_LEGEND_PROFILE,
+    )
+
+    with patch("api.legends.get_supabase", return_value=supabase):
+        with app.test_client() as client:
+            resp = client.get(f"/api/legends/{LEGEND_ID}?source=draft")
+
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    profile = body["data"]["profile"]
+    assert profile.get("Scorer") == "Capable", (
+        f"Admin draft source should return draft Scorer=Capable, got {profile.get('Scorer')!r}"
+    )
+
+    table_calls = [c.args[0] for c in supabase.table.call_args_list]
+    assert "draft_skill_profiles" in table_calls
+    assert "released_players" not in table_calls
+
+
+def test_lab_legends_list_returns_503_when_no_active_release(app):
+    """GET /api/legends with no active release returns 503 no_active_release."""
+    from services.snapshots_active import ActiveReleaseMissingError
+
+    supabase = _make_supabase_for_legends_route(
+        legend_released_profile=RELEASED_LEGEND_PROFILE,
+        legend_draft_profile=DRAFT_MUTATED_LEGEND_PROFILE,
+    )
+
+    with (
+        patch("api.legends.get_supabase", return_value=supabase),
+        patch(
+            "api.legends.get_active_release_id",
+            side_effect=ActiveReleaseMissingError("no active release"),
+        ),
+    ):
+        with app.test_client() as client:
+            resp = client.get("/api/legends")
 
     assert resp.status_code == 503
     body = resp.get_json()

--- a/backend/tests/test_lab_read_pin.py
+++ b/backend/tests/test_lab_read_pin.py
@@ -8,7 +8,7 @@ Contract under test (M3):
 - GET /api/players (legends section) reads released_players for legend profiles.
 - flag_summary is always {total: 0, unresolved: 0} on Lab reads (no flag table
   in released_players).
-- ActiveReleaseMissingError in snapshots_active → 503 from Lab routes.
+- ActiveReleaseMissingError in snapshot_versions.active → 503 from Lab routes.
 
 All tests use Flask test client with patched DB dependencies — no live DB needed.
 """
@@ -413,7 +413,7 @@ def test_draft_edit_does_not_leak_to_legends_listing(app):
 
 
 # ---------------------------------------------------------------------------
-# snapshots_active.get_active_release_id unit tests
+# snapshot_versions.active.get_active_release_id unit tests
 # ---------------------------------------------------------------------------
 
 
@@ -430,10 +430,10 @@ class _FakeRelease:
 
 def test_get_active_release_id_returns_id_outside_request():
     """Outside a request context, returns the release id from repo."""
-    from services.snapshots_active import get_active_release_id
+    from services.snapshot_versions.active import get_active_release_id
 
     with patch(
-        "services.snapshots_active._query_active_release_id",
+        "services.snapshot_versions.active._query_active_release_id",
         return_value=ACTIVE_RELEASE_ID,
     ):
         result = get_active_release_id()
@@ -443,7 +443,7 @@ def test_get_active_release_id_returns_id_outside_request():
 
 def test_get_active_release_id_memoizes_within_request(app):
     """Within a request context, repeated calls return cached value without re-querying."""
-    from services.snapshots_active import get_active_release_id
+    from services.snapshot_versions.active import get_active_release_id
 
     call_count = 0
 
@@ -452,7 +452,7 @@ def test_get_active_release_id_memoizes_within_request(app):
         call_count += 1
         return ACTIVE_RELEASE_ID
 
-    with patch("services.snapshots_active._query_active_release_id", side_effect=_fake_query):
+    with patch("services.snapshot_versions.active._query_active_release_id", side_effect=_fake_query):
         with app.test_request_context("/"):
             id1 = get_active_release_id()
             id2 = get_active_release_id()
@@ -464,10 +464,10 @@ def test_get_active_release_id_memoizes_within_request(app):
 
 def test_get_active_release_id_raises_on_missing_release():
     """Raises ActiveReleaseMissingError when repo raises."""
-    from services.snapshots_active import get_active_release_id, ActiveReleaseMissingError
+    from services.snapshot_versions.active import get_active_release_id, ActiveReleaseMissingError
 
     with patch(
-        "services.snapshots_active._query_active_release_id",
+        "services.snapshot_versions.active._query_active_release_id",
         side_effect=ActiveReleaseMissingError("no active release"),
     ):
         with pytest.raises(ActiveReleaseMissingError):
@@ -476,7 +476,7 @@ def test_get_active_release_id_raises_on_missing_release():
 
 def test_get_active_release_id_does_not_memoize_outside_request():
     """Outside a request context, every call hits _query_active_release_id."""
-    from services.snapshots_active import get_active_release_id
+    from services.snapshot_versions.active import get_active_release_id
 
     call_count = 0
 
@@ -485,7 +485,7 @@ def test_get_active_release_id_does_not_memoize_outside_request():
         call_count += 1
         return ACTIVE_RELEASE_ID
 
-    with patch("services.snapshots_active._query_active_release_id", side_effect=_fake_query):
+    with patch("services.snapshot_versions.active._query_active_release_id", side_effect=_fake_query):
         get_active_release_id()
         get_active_release_id()
 
@@ -499,7 +499,7 @@ def test_get_active_release_id_does_not_memoize_outside_request():
 
 def test_player_detail_returns_503_when_no_active_release(app):
     """GET /api/players/<id>/profile returns 503 when ActiveReleaseMissingError raised."""
-    from services.snapshots_active import ActiveReleaseMissingError
+    from services.snapshot_versions.active import ActiveReleaseMissingError
 
     supabase = MagicMock()
     q = MagicMock()
@@ -724,7 +724,7 @@ def test_admin_legends_detail_reads_draft_when_source_draft(app):
 
 def test_lab_legends_list_returns_503_when_no_active_release(app):
     """GET /api/legends with no active release returns 503 no_active_release."""
-    from services.snapshots_active import ActiveReleaseMissingError
+    from services.snapshot_versions.active import ActiveReleaseMissingError
 
     supabase = _make_supabase_for_legends_route(
         legend_released_profile=RELEASED_LEGEND_PROFILE,

--- a/backend/tests/test_lab_read_pin.py
+++ b/backend/tests/test_lab_read_pin.py
@@ -1,0 +1,542 @@
+"""
+test_lab_read_pin.py — Integration tests asserting that draft edits do NOT
+leak to Lab-facing read Surfaces.
+
+Contract under test (M3):
+- GET /api/players/<id>/profile reads released_players, not draft_skill_profiles.
+- GET /api/players (bulk) reads released_players for composite profiles.
+- GET /api/players (legends section) reads released_players for legend profiles.
+- flag_summary is always {total: 0, unresolved: 0} on Lab reads (no flag table
+  in released_players).
+- ActiveReleaseMissingError in snapshots_active → 503 from Lab routes.
+
+All tests use Flask test client with patched DB dependencies — no live DB needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, call
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ACTIVE_RELEASE_ID = "aaaaaaaa-0000-0000-0000-000000000001"
+PLAYER_ID = "bbbbbbbb-0000-0000-0000-000000000001"
+LEGEND_ID = "cccccccc-0000-0000-0000-000000000001"
+CANONICAL_PLAYER_ID = "dddddddd-0000-0000-0000-000000000001"
+NBA_API_ID = 1234567
+
+RELEASED_PROFILE = {
+    "Scorer": {"final_tier": "Elite", "stat_tier": "Elite", "claude_tier": "Elite"},
+    "RimProtector": {"final_tier": "None"},
+}
+
+DRAFT_MUTATED_PROFILE = {
+    "Scorer": {"final_tier": "Capable", "stat_tier": "Capable", "claude_tier": "Capable"},
+    "RimProtector": {"final_tier": "None"},
+}
+
+RELEASED_LEGEND_PROFILE = {
+    "Scorer": "Elite",
+    "RimProtector": "Proficient",
+}
+
+DRAFT_MUTATED_LEGEND_PROFILE = {
+    "Scorer": "Capable",
+    "RimProtector": "None",
+}
+
+SEASON = "2025-26"
+
+
+# ---------------------------------------------------------------------------
+# Fake DB helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+def _make_supabase_with_released_player(profile: dict) -> MagicMock:
+    """Build a mock Supabase client that returns the given profile from released_players
+    and an unrelated row from draft_skill_profiles for the same player.
+    """
+    supabase = MagicMock()
+
+    def table_side_effect(name: str):
+        q = MagicMock()
+        q.select.return_value = q
+        q.eq.return_value = q
+        q.in_.return_value = q
+        q.or_.return_value = q
+        q.order.return_value = q
+        q.limit.return_value = q
+        q.single.return_value = q
+
+        if name == "players":
+            q.execute.return_value = _FakeResult([{
+                "id": PLAYER_ID,
+                "name": "Test Player",
+                "team": "LAL",
+                "position": "SF",
+                "age": 28,
+                "games_played": 70,
+                "minutes_per_game": 34.0,
+                "salary": 10_000_000,
+                "height": 79,
+                "weight": 220,
+                "season": SEASON,
+                "nba_api_id": NBA_API_ID,
+                "manually_included": False,
+            }])
+        elif name == "released_players":
+            q.execute.return_value = _FakeResult([{
+                "id": "rp-row-001",
+                "snapshot_release_id": ACTIVE_RELEASE_ID,
+                "canonical_player_id": CANONICAL_PLAYER_ID,
+                "source_player_id": PLAYER_ID,
+                "skill_profile_snapshot": profile,
+                "name": "Test Player",
+                "team": "LAL",
+                "position": "SF",
+                "salary": 10_000_000,
+                "stat_season": SEASON,
+                "is_legend": False,
+            }])
+        elif name == "draft_skill_profiles":
+            # Draft has a DIFFERENT (mutated) profile — should NOT appear in Lab reads
+            q.execute.return_value = _FakeResult([{
+                "id": "dsp-row-001",
+                "player_id": PLAYER_ID,
+                "season": SEASON,
+                "source": "composite",
+                "profile": DRAFT_MUTATED_PROFILE,
+            }])
+        elif name == "draft_skill_flags":
+            q.execute.return_value = _FakeResult([
+                {"id": "flag-001", "resolution": None},
+                {"id": "flag-002", "resolution": None},
+            ])
+        else:
+            q.execute.return_value = _FakeResult([])
+
+        return q
+
+    supabase.table.side_effect = table_side_effect
+    return supabase
+
+
+def _make_supabase_with_released_legends(legend_profile: dict) -> MagicMock:
+    """Build a mock Supabase client for the legends listing read site."""
+    supabase = MagicMock()
+
+    def table_side_effect(name: str):
+        q = MagicMock()
+        q.select.return_value = q
+        q.eq.return_value = q
+        q.in_.return_value = q
+        q.or_.return_value = q
+        q.order.return_value = q
+        q.limit.return_value = q
+        q.single.return_value = q
+
+        if name == "legends":
+            q.execute.return_value = _FakeResult([{
+                "id": LEGEND_ID,
+                "name": "Hakeem Olajuwon",
+                "team": None,
+                "position": "C",
+                "age": None,
+                "height": 84,
+                "weight": 255,
+                "peak_year": 1994,
+                "nba_api_id": NBA_API_ID,
+            }])
+        elif name == "released_players":
+            q.execute.return_value = _FakeResult([{
+                "id": "rp-legend-001",
+                "snapshot_release_id": ACTIVE_RELEASE_ID,
+                "canonical_player_id": CANONICAL_PLAYER_ID,
+                "source_player_id": None,
+                "skill_profile_snapshot": legend_profile,
+                "name": "Hakeem Olajuwon",
+                "team": None,
+                "position": "C",
+                "salary": 54_000_000,
+                "stat_season": None,
+                "is_legend": True,
+            }])
+        elif name == "canonical_players":
+            q.execute.return_value = _FakeResult([{
+                "id": CANONICAL_PLAYER_ID,
+                "nba_api_id": NBA_API_ID,
+            }])
+        elif name == "draft_skill_profiles":
+            # Draft legend row with mutated profile — must NOT leak
+            q.execute.return_value = _FakeResult([{
+                "id": "dsp-legend-001",
+                "legend_id": LEGEND_ID,
+                "is_legend": True,
+                "source": "manual",
+                "profile": DRAFT_MUTATED_LEGEND_PROFILE,
+            }])
+        else:
+            q.execute.return_value = _FakeResult([])
+
+        return q
+
+    supabase.table.side_effect = table_side_effect
+    return supabase
+
+
+# ---------------------------------------------------------------------------
+# App fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def app():
+    app = create_app()
+    app.config["TESTING"] = True
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Tracer bullet: single Player detail does NOT expose draft edits
+# ---------------------------------------------------------------------------
+
+
+def test_draft_edit_does_not_leak_to_lab_player_detail(app):
+    """
+    Arrange: active release has Scorer=Elite; draft_skill_profiles mutated to Capable.
+    Act: GET /api/players/<id>/profile
+    Assert: response returns Scorer=Elite (from released_players), NOT Capable (from draft).
+    Also assert: flag_summary is {total: 0, unresolved: 0} — no flag table on released path.
+    """
+    supabase = _make_supabase_with_released_player(RELEASED_PROFILE)
+
+    with (
+        patch("api.players.get_supabase", return_value=supabase),
+        patch(
+            "services.snapshots_active.get_active_release_id",
+            return_value=ACTIVE_RELEASE_ID,
+        ),
+    ):
+        with app.test_client() as client:
+            resp = client.get(
+                f"/api/players/{PLAYER_ID}/profile",
+                query_string={"season": SEASON},
+            )
+
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["success"] is True
+    skills = body["data"]["skills"]
+    scorer = skills.get("Scorer")
+    assert scorer is not None, f"Scorer key missing from skills: {skills}"
+    # Accept dict shape {"final_tier": ...} or plain string tier
+    if isinstance(scorer, dict):
+        tier = scorer.get("final_tier")
+    else:
+        tier = scorer
+    assert tier == "Elite", (
+        f"Expected Scorer=Elite (released), got {tier!r} — draft leak detected"
+    )
+
+    flag_summary = body["data"]["flag_summary"]
+    assert flag_summary == {"total": 0, "unresolved": 0}, (
+        f"flag_summary should be zero on Lab reads, got {flag_summary}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bulk players list does NOT expose draft edits
+# ---------------------------------------------------------------------------
+
+
+def test_draft_edit_does_not_leak_to_bulk_players_list(app):
+    """
+    Arrange: active release has Scorer=Elite; draft_skill_profiles mutated to Capable.
+    Act: GET /api/players/bulk (bulk list for the active season)
+    Assert: the player's composite profile reflects released tier, not draft tier.
+    """
+    supabase = MagicMock()
+
+    players_row = {
+        "id": PLAYER_ID,
+        "name": "Test Player",
+        "team": "LAL",
+        "position": "SF",
+        "age": 28,
+        "games_played": 70,
+        "minutes_per_game": 34.0,
+        "salary": 10_000_000,
+        "height": 79,
+        "weight": 220,
+        "season": SEASON,
+        "nba_api_id": NBA_API_ID,
+        "manually_included": False,
+        "draft_round": None,
+        "season_exp": 5,
+    }
+
+    released_row = {
+        "id": "rp-row-002",
+        "snapshot_release_id": ACTIVE_RELEASE_ID,
+        "canonical_player_id": CANONICAL_PLAYER_ID,
+        "source_player_id": PLAYER_ID,
+        "skill_profile_snapshot": RELEASED_PROFILE,
+        "name": "Test Player",
+        "team": "LAL",
+        "position": "SF",
+        "salary": 10_000_000,
+        "is_legend": False,
+    }
+
+    def table_side_effect(name: str):
+        q = MagicMock()
+        q.select.return_value = q
+        q.eq.return_value = q
+        q.in_.return_value = q
+        q.or_.return_value = q
+        q.order.return_value = q
+        q.limit.return_value = q
+
+        if name == "players":
+            q.execute.return_value = _FakeResult([players_row])
+        elif name == "released_players":
+            q.execute.return_value = _FakeResult([released_row])
+        elif name == "draft_skill_profiles":
+            # Should NOT be queried on Lab path after M3
+            q.execute.return_value = _FakeResult([{
+                "id": "dsp-002",
+                "player_id": PLAYER_ID,
+                "season": SEASON,
+                "source": "composite",
+                "profile": DRAFT_MUTATED_PROFILE,
+            }])
+        elif name == "draft_skill_flags":
+            q.execute.return_value = _FakeResult([
+                {"id": "flag-001", "resolution": None},
+            ])
+        else:
+            q.execute.return_value = _FakeResult([])
+
+        return q
+
+    supabase.table.side_effect = table_side_effect
+
+    with (
+        patch("api.players.get_supabase", return_value=supabase),
+        patch(
+            "services.snapshots_active.get_active_release_id",
+            return_value=ACTIVE_RELEASE_ID,
+        ),
+    ):
+        with app.test_client() as client:
+            resp = client.get("/api/players/bulk", query_string={"season": SEASON})
+
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["success"] is True
+    players = body["data"] if isinstance(body["data"], list) else body["data"].get("players", [])
+    assert isinstance(players, list)
+    assert len(players) >= 1
+
+    player = next((p for p in players if p["id"] == PLAYER_ID), None)
+    assert player is not None, f"Expected player {PLAYER_ID} in response"
+
+    skills = player.get("skills")
+    assert skills is not None, "skills key missing"
+    scorer = skills.get("Scorer")
+    if isinstance(scorer, dict):
+        tier = scorer.get("final_tier")
+    else:
+        tier = scorer
+    assert tier == "Elite", (
+        f"Expected Scorer=Elite (released), got {tier!r} — draft leak detected"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Legend listing does NOT expose draft edits
+# ---------------------------------------------------------------------------
+
+
+def test_draft_edit_does_not_leak_to_legends_listing(app):
+    """
+    Arrange: active release has legend Scorer=Elite; draft_skill_profiles mutated to Capable.
+    Act: GET /api/players (legends=true or legends section)
+    Assert: legend's skill profile reflects released tier.
+    """
+    supabase = _make_supabase_with_released_legends(RELEASED_LEGEND_PROFILE)
+
+    with (
+        patch("api.players.get_supabase", return_value=supabase),
+        patch(
+            "services.snapshots_active.get_active_release_id",
+            return_value=ACTIVE_RELEASE_ID,
+        ),
+    ):
+        with app.test_client() as client:
+            resp = client.get("/api/players/bulk", query_string={"include_legends": "true"})
+
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["success"] is True
+    players = body["data"] if isinstance(body["data"], list) else body["data"].get("players", [])
+    assert isinstance(players, list)
+
+    legend = next((p for p in players if p.get("is_legend") is True), None)
+    assert legend is not None, f"No legend entry in response: {players}"
+
+    skills = legend.get("skills")
+    assert skills is not None
+    scorer = skills.get("Scorer")
+    if isinstance(scorer, dict):
+        tier = scorer.get("final_tier")
+    else:
+        tier = scorer
+    assert tier == "Elite", (
+        f"Expected Scorer=Elite (released), got {tier!r} — draft legend leak detected"
+    )
+
+
+# ---------------------------------------------------------------------------
+# snapshots_active.get_active_release_id unit tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeRelease:
+    def __init__(self, release_id: str):
+        self.id = release_id
+        self.label = "test"
+        self.season = SEASON
+        self.status = "published"
+        self.is_active = True
+        self.published_at = None
+        self.created_at = "2026-01-01T00:00:00Z"
+
+
+def test_get_active_release_id_returns_id_outside_request():
+    """Outside a request context, returns the release id from repo."""
+    from services.snapshots_active import get_active_release_id
+
+    with patch(
+        "services.snapshots_active._query_active_release_id",
+        return_value=ACTIVE_RELEASE_ID,
+    ):
+        result = get_active_release_id()
+
+    assert result == ACTIVE_RELEASE_ID
+
+
+def test_get_active_release_id_memoizes_within_request(app):
+    """Within a request context, repeated calls return cached value without re-querying."""
+    from services.snapshots_active import get_active_release_id
+
+    call_count = 0
+
+    def _fake_query(client=None) -> str:
+        nonlocal call_count
+        call_count += 1
+        return ACTIVE_RELEASE_ID
+
+    with patch("services.snapshots_active._query_active_release_id", side_effect=_fake_query):
+        with app.test_request_context("/"):
+            id1 = get_active_release_id()
+            id2 = get_active_release_id()
+            id3 = get_active_release_id()
+
+    assert id1 == id2 == id3 == ACTIVE_RELEASE_ID
+    assert call_count == 1, f"Expected 1 DB call (memoized), got {call_count}"
+
+
+def test_get_active_release_id_raises_on_missing_release():
+    """Raises ActiveReleaseMissingError when repo raises."""
+    from services.snapshots_active import get_active_release_id, ActiveReleaseMissingError
+
+    with patch(
+        "services.snapshots_active._query_active_release_id",
+        side_effect=ActiveReleaseMissingError("no active release"),
+    ):
+        with pytest.raises(ActiveReleaseMissingError):
+            get_active_release_id()
+
+
+def test_get_active_release_id_does_not_memoize_outside_request():
+    """Outside a request context, every call hits _query_active_release_id."""
+    from services.snapshots_active import get_active_release_id
+
+    call_count = 0
+
+    def _fake_query(client=None) -> str:
+        nonlocal call_count
+        call_count += 1
+        return ACTIVE_RELEASE_ID
+
+    with patch("services.snapshots_active._query_active_release_id", side_effect=_fake_query):
+        get_active_release_id()
+        get_active_release_id()
+
+    assert call_count == 2, f"Expected 2 DB calls (no memoization outside request), got {call_count}"
+
+
+# ---------------------------------------------------------------------------
+# Lab routes return 503 when no active release exists
+# ---------------------------------------------------------------------------
+
+
+def test_player_detail_returns_503_when_no_active_release(app):
+    """GET /api/players/<id>/profile returns 503 when ActiveReleaseMissingError raised."""
+    from services.snapshots_active import ActiveReleaseMissingError
+
+    supabase = MagicMock()
+    q = MagicMock()
+    q.select.return_value = q
+    q.eq.return_value = q
+    q.limit.return_value = q
+    q.execute.return_value = _FakeResult([{
+        "id": PLAYER_ID,
+        "name": "Test Player",
+        "team": "LAL",
+        "position": "SF",
+        "age": 28,
+        "games_played": 70,
+        "minutes_per_game": 34.0,
+        "salary": 10_000_000,
+        "height": 79,
+        "weight": 220,
+        "season": SEASON,
+        "nba_api_id": NBA_API_ID,
+        "manually_included": False,
+    }])
+    supabase.table.return_value = q
+
+    with (
+        patch("api.players.get_supabase", return_value=supabase),
+        patch(
+            "services.snapshots_active.get_active_release_id",
+            side_effect=ActiveReleaseMissingError("no active release"),
+        ),
+    ):
+        with app.test_client() as client:
+            resp = client.get(
+                f"/api/players/{PLAYER_ID}/profile",
+                query_string={"season": SEASON},
+            )
+
+    assert resp.status_code == 503
+    body = resp.get_json()
+    assert body["success"] is False
+    assert "no_active_release" in body["error"]

--- a/frontend/app/admin/legends/[legend_id]/page.tsx
+++ b/frontend/app/admin/legends/[legend_id]/page.tsx
@@ -206,7 +206,10 @@ export default function LegendEditorPage() {
   // Load legend data + all legends for navigation
   useEffect(() => {
     setLoading(true);
-    Promise.all([getLegend(legendId), listLegends()]).then(([legendRes, listRes]) => {
+    Promise.all([
+      getLegend(legendId, { source: "draft" }),
+      listLegends({ source: "draft" }),
+    ]).then(([legendRes, listRes]) => {
       if (legendRes.success && legendRes.data) {
         setLegend(legendRes.data);
         setProfile(legendRes.data.profile);

--- a/frontend/app/admin/legends/page.tsx
+++ b/frontend/app/admin/legends/page.tsx
@@ -108,7 +108,7 @@ export default function LegendsPage() {
 
   useEffect(() => {
     setLoading(true);
-    listLegends()
+    listLegends({ source: "draft" })
       .then((res) => {
         if (res.success && res.data) {
           setLegends(res.data);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -533,9 +533,18 @@ export async function searchPlayers(
 // Legends (Prompt 8)
 // ---------------------------------------------------------------------------
 
-/** Get all 36 legends with completion counts (lightweight — no full profiles). */
-export async function listLegends(): Promise<ApiResponse<LegendSummary[]>> {
-  return apiFetch<LegendSummary[]>("/api/legends");
+/**
+ * Get all legends with completion counts (lightweight — no full profiles).
+ *
+ * Default source is the active Snapshot Release (Lab Contract — frozen
+ * ratings, invisible to in-progress admin edits). Admin pages MUST pass
+ * `source: "draft"` to see in-progress draft ratings.
+ */
+export async function listLegends(
+  options?: { source?: "released" | "draft" }
+): Promise<ApiResponse<LegendSummary[]>> {
+  const source = options?.source ?? "released";
+  return apiFetch<LegendSummary[]>(`/api/legends?source=${source}`);
 }
 
 /**
@@ -546,9 +555,21 @@ export async function listActivePlayersWithSkills(): Promise<ApiResponse<PlayerW
   return apiFetch<PlayerWithSkills[]>("/api/players/bulk?include_legends=false");
 }
 
-/** Get a single legend with its full skill profile. */
-export async function getLegend(legendId: string): Promise<ApiResponse<LegendDetail>> {
-  return apiFetch<LegendDetail>(`/api/legends/${encodeURIComponent(legendId)}`);
+/**
+ * Get a single legend with its full skill profile.
+ *
+ * Default source is the active Snapshot Release (Lab Contract — frozen
+ * ratings, invisible to in-progress admin edits). Admin pages MUST pass
+ * `source: "draft"` to see in-progress draft ratings.
+ */
+export async function getLegend(
+  legendId: string,
+  options?: { source?: "released" | "draft" }
+): Promise<ApiResponse<LegendDetail>> {
+  const source = options?.source ?? "released";
+  return apiFetch<LegendDetail>(
+    `/api/legends/${encodeURIComponent(legendId)}?source=${source}`
+  );
 }
 
 /**

--- a/supabase/migrations/20260527000012_publish_legend_source_fix.sql
+++ b/supabase/migrations/20260527000012_publish_legend_source_fix.sql
@@ -1,0 +1,183 @@
+-- =============================================================================
+-- M3 follow-up: fix legend branch of publish_snapshot_draft RPC.
+--
+-- Defect (caught by codex adversarial review on PR #60):
+--   The publish RPC's legend_profiles CTE filtered draft_skill_profiles by
+--   source = 'composite' AND is_legend = true. Legend Skill Profiles are
+--   written exclusively by the /admin/legends editor with source = 'manual'
+--   (see backend/api/legends.py PUT /legends/<id>/skills, which upserts the
+--   manual row). No 'composite' rows exist for legends, so every published
+--   legend ended up with skill_profile_snapshot = '{}' in released_players.
+--   After M3's Lab read pin (which routes Lab/legends reads at
+--   backend/api/legends.py through released_players), the empty snapshots
+--   would surface as "all skills unrated" for every legend.
+--
+-- Fix: legend CTE filter changes source = 'composite' -> source = 'manual'.
+-- Regular-player branch unchanged (regular Players keep source = 'composite').
+--
+-- This is a CREATE OR REPLACE of the full body to keep the legend join,
+-- canonical-link preflight, open-flags gate, missing-composite check, and
+-- advisory-lock semantics intact.
+--
+-- The previously-granted ACL (REVOKE from anon/authenticated/PUBLIC; GRANT to
+-- service_role) is preserved by CREATE OR REPLACE — Postgres does not reset
+-- function grants when the body changes. The secdef-lint allow-public comment
+-- mirrors the upstream copy in 20260527000003 and remains valid because the
+-- function is still locked down via 20260527000010_secdef_rpc_lockdown.sql.
+-- =============================================================================
+
+-- secdef-lint: allow-public reason=hardened-in-20260527000010_secdef_rpc_lockdown
+CREATE OR REPLACE FUNCTION public.publish_snapshot_draft(
+  p_draft_id                UUID,
+  p_label                   TEXT,
+  p_allow_missing_composite BOOLEAN DEFAULT false,
+  p_allow_open_flags        BOOLEAN DEFAULT false
+)
+RETURNS public.snapshot_releases
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_release             public.snapshot_releases;
+  v_missing_composite   INTEGER;
+  v_open_flags          INTEGER;
+  v_legends_no_canonical INTEGER;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('snapshot_releases.active_swap'));
+
+  SELECT * INTO v_release
+    FROM public.snapshot_releases
+    WHERE id = p_draft_id AND status IN ('draft', 'review')
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'draft_not_found_or_not_in_draft_state';
+  END IF;
+
+  -- Missing-composite check (regular players only — legends excluded).
+  SELECT COUNT(*) INTO v_missing_composite
+  FROM public.players p
+  LEFT JOIN public.draft_skill_profiles sp
+    ON sp.player_id = p.id AND sp.source = 'composite' AND sp.is_legend = false
+  WHERE p.season = '2025-26' AND sp.id IS NULL;
+
+  IF v_missing_composite > 0 AND NOT p_allow_missing_composite THEN
+    RAISE EXCEPTION 'missing_composite_not_acknowledged: % players', v_missing_composite;
+  END IF;
+
+  -- Open-flags check.
+  SELECT COUNT(*) INTO v_open_flags
+  FROM public.draft_skill_flags
+  WHERE resolution IS NULL;
+
+  IF v_open_flags > 0 AND NOT p_allow_open_flags THEN
+    RAISE EXCEPTION 'open_flags_not_acknowledged: % flags', v_open_flags;
+  END IF;
+
+  -- Legend canonical-link preflight.
+  SELECT COUNT(*) INTO v_legends_no_canonical
+  FROM public.legends l
+  LEFT JOIN public.canonical_players cp ON cp.nba_api_id = l.nba_api_id
+  WHERE cp.id IS NULL;
+
+  IF v_legends_no_canonical > 0 THEN
+    RAISE EXCEPTION 'legends_missing_canonical_player: % legends', v_legends_no_canonical;
+  END IF;
+
+  -- Freeze into released_players: regular players UNION ALL legends.
+  WITH regular_profiles AS (
+    SELECT DISTINCT ON (player_id) id, player_id, profile
+    FROM public.draft_skill_profiles
+    WHERE source = 'composite' AND is_legend = false
+    ORDER BY player_id, updated_at DESC NULLS LAST, created_at DESC NULLS LAST
+  ),
+  -- FIX (M3 follow-up): legend rows are written with source = 'manual' by the
+  -- /admin/legends editor — never 'composite'. The prior 'composite' filter
+  -- yielded zero rows for every legend, producing empty Skill Profile
+  -- snapshots in released_players. Switch to 'manual'.
+  legend_profiles AS (
+    SELECT DISTINCT ON (legend_id) id, legend_id, profile
+    FROM public.draft_skill_profiles
+    WHERE source = 'manual' AND is_legend = true
+    ORDER BY legend_id, updated_at DESC NULLS LAST, created_at DESC NULLS LAST
+  )
+  INSERT INTO public.released_players (
+    snapshot_release_id,
+    canonical_player_id,
+    source_player_id,
+    source_skill_profile_id,
+    stat_season,
+    name,
+    team,
+    position,
+    salary,
+    skill_profile_snapshot,
+    is_legend
+  )
+  SELECT
+    p_draft_id,
+    cp.id,
+    p.id,
+    sp.id,
+    p.season,
+    p.name,
+    p.team,
+    p.position,
+    COALESCE(p.salary, 0),
+    COALESCE(sp.profile, '{}'::jsonb),
+    false
+  FROM public.players p
+  JOIN public.canonical_players cp ON cp.nba_api_id = p.nba_api_id
+  LEFT JOIN regular_profiles sp ON sp.player_id = p.id
+  WHERE p.season = '2025-26'
+
+  UNION ALL
+
+  SELECT
+    p_draft_id,
+    cp.id,
+    NULL,
+    lp.id,
+    '2025-26',
+    l.name,
+    l.team,
+    l.position,
+    0,
+    COALESCE(lp.profile, '{}'::jsonb),
+    true
+  FROM public.legends l
+  JOIN public.canonical_players cp ON cp.nba_api_id = l.nba_api_id
+  LEFT JOIN legend_profiles lp ON lp.legend_id = l.id;
+
+  UPDATE public.snapshot_releases
+    SET is_active = false
+    WHERE is_active = true;
+
+  UPDATE public.snapshot_releases
+    SET
+      status         = 'published',
+      is_active      = true,
+      label          = p_label,
+      published_at   = now(),
+      data_cutoff_at = now()
+    WHERE id = p_draft_id
+    RETURNING * INTO v_release;
+
+  RETURN v_release;
+END;
+$$;
+
+-- =============================================================================
+-- Verification after apply:
+--   1. Open any published Snapshot Release in production where legends exist.
+--      SELECT COUNT(*) FROM released_players
+--       WHERE snapshot_release_id = '<release-id>'
+--         AND is_legend = true
+--         AND skill_profile_snapshot != '{}'::jsonb;
+--      -- Pre-fix: 0. Post-fix (after a fresh publish): matches the count of
+--      -- legends with non-empty draft manual profiles.
+--
+--   2. Re-publish the current draft (or open a fresh one) and confirm
+--      released_players legend rows now carry the manual ratings.
+-- =============================================================================


### PR DESCRIPTION
## Summary

M3 of the draft-aware skill-mapping plan (#7). Migrates every Lab/players read of `draft_skill_profiles` → `released_players` filtered by the currently-active Snapshot Release. Admin Surfaces continue reading draft tables; the draft → Lab Boundary now holds until publish.

Closes the M3 milestone in `feature_requests/draft-aware-skill-mapping-plan.md`.

## Changes

**New Seam — `backend/services/snapshots_active.py`**
- `get_active_release_id()` with per-request memoization via `flask.g`
- `ActiveReleaseMissingError` raised when no active release exists
- Wraps existing `snapshot_versions.repo.get_active_release` (no duplicate query)

**Read-site migration**
- `backend/api/players.py` — new `_fetch_released_profiles` helper with fail-fast dual-param guard. Swapped 3 read sites: player detail, bulk list, legends listing.
- `backend/services/cohesion_engine/composites.py` — swapped 2 warmup read sites in `build_distributions`. Degrades to empty distribution if no active release at boot.

**Failure modes**
- Lab routes return 503 `{ "error": "no_active_release" }` (opaque code; details server-side only).
- Retry path catches `ActiveReleaseMissingError` before generic `Exception` so the error string is not leaked through `_err()`.
- `flag_summary` is always `{ total: 0, unresolved: 0 }` on Lab paths — flags are admin/draft-only.

## Test plan

- [x] `pytest tests/test_lab_read_pin.py -v` — 8/8 GREEN
  - draft edit invisible on player detail, bulk list, legends listing
  - Seam memoization scope (in-request vs out-of-request)
  - `ActiveReleaseMissingError` raised on missing release
  - 503 on player detail when no active release
- [x] `pytest tests/` full backend suite — 634 passed, 3 pre-existing flakes unchanged (`test_full_nine_player_roster_evaluates_126_lineups_under_100ms`, `test_compute_player_composites_returns_dataclass_with_bell_params`, `test_normalize_composites_guards_zero_theoretical_max` — documented as pre-existing in plan Surprises)
- [ ] Manual: open `/players/<id>` while draft has a mutated tier; UI shows released tier
- [ ] Manual: publish draft; restart Flask; `/players/<id>` now shows new tier

## Security audit

Service-role Supabase client confirmed on all read paths. No `draft_skill_profiles` references on unauthenticated Lab routes. 503 returns opaque codes, no stack traces.

## Out of scope (deferred)

- Hot-reload of cohesion distribution on release flip (Flask restart required).
- `backend/api/composite.py` admin recompute path (stays on draft tables).
- Frontend changes (response shape unchanged).
- Live-DB integration tests for the Boundary (mock-level coverage only; track for M7).

## Closes

- Closes #63
